### PR TITLE
Use Yeoman log to output usage end message instead of using Console object

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -112,11 +112,13 @@ var AspnetGenerator = yeoman.generators.Base.extend({
     end: function () {
         this.log(this.cacheRoot());
         if (!this.options['skip-install']) {
-            this.log('\r\nYour project is now created, you can use the following commands to get going');
+            this.log('\r\n');
+            this.log('Your project is now created, you can use the following commands to get going');
             this.log(chalk.green('    kpm restore'));
             this.log(chalk.green('    kpm build'));
             this.log(chalk.green('    k run') + ' for console projects');
-            this.log(chalk.green('    k kestrel') + 'or' + chalk.green('k web') + 'for web projects\r\n');
+            this.log(chalk.green('    k kestrel') + 'or' + chalk.green('k web') + 'for web projects');
+            this.log('\r\n');
         }
     }
 });


### PR DESCRIPTION
This PR is trivial. It removes use of Console from source code and uses built-in Yeoman log to output messages:
https://github.com/yeoman/generator/blob/master/lib/base.js#L124-L126
The reasoning for this is to cleanup code and use single method across project's source code to output messages
The second commit is purely cosmetic, but I think can help to avoid future problems when wording is to be changed in end messages.

If you want commits to be rebased, just let me know.
