### PR TITLE
Add web root directory to web sample

### DIFF
--- a/samples/web/project.json
+++ b/samples/web/project.json
@@ -1,4 +1,5 @@
 {
+  "webroot": "wwwroot",
   "version": "0.1-alpha-*",
   "dependencies": {
     "Microsoft.AspNet.Server.IIS":"1.0.0-beta1",

--- a/samples/web/wwwroot/README.md
+++ b/samples/web/wwwroot/README.md
@@ -1,0 +1,5 @@
+> All of the static files in your project go into this folder. These are assets that the app will serve directly to clients, including HTML files, CSS files, image files, and JavaScript files. The `wwwroot` folder is the root of your web site. That is, `http://hostname/` points to `wwwroot`, all URLs for static content are relative to the `wwwroot` folder.
+
+We have taken the quote above on the role of the `wwwroot` directory, the static files and assets in the vNext projects, from this excellent article on ASP.NET (which you should read for all the details):
+
+[http://www.asp.net/vnext/overview/aspnet-vnext/grunt-and-bower-in-visual-studio-2015#static-files](http://www.asp.net/vnext/overview/aspnet-vnext/grunt-and-bower-in-visual-studio-2015#static-files)


### PR DESCRIPTION
This PR adds empty web root directory for Web type sample used by generator. The web root directory is specified in project file (also modified) and follows MVC sample.
This closes #1 of:
https://github.com/OmniSharp/generator-aspnet/issues/31