### PR TITLE
Fix character case in usage code snippet

### DIFF
--- a/Gulpfile/USAGE
+++ b/Gulpfile/USAGE
@@ -2,7 +2,7 @@ Description:
 	Creates a new Gulp file
 
 Example:
-	yo aspnet:GulpFile
+	yo aspnet:Gulpfile
 
 	This will create:
 		gulpfile.js


### PR DESCRIPTION
This PR fixes small bug in subgenerator documentation:

Running:
```
yo aspnet:GulpFile
```
outputs:
```
     _-----_
    |       |    .--------------------------.
    |--(o)--|    |      Welcome to the      |
   `---------´   |   marvellous ASP.NET 5   |
    ( _´U`_ )    |        generator!        |
    /___A___\    '--------------------------'
     |  ~  |     
   __'.___.'__   
 ´   `  |° ´ Y ` 

? What type of application do you want to create? (Use arrow keys)
❯ Console Application 
  Web Application 
  MVC Application 
  Nancy ASP.NET Application 
  Class Library 
  Unit test project 
```
while expected results are:
```
You called the aspnet subgenerator with the arg gulpfile.js
gulpfile.js created.
   create gulpfile.js
```