### PR TITLE
Show generic error and exit on network error. Fixes #55

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -88,9 +88,14 @@ var AspnetGenerator = yeoman.generators.Base.extend({
 
     retrieveContent: function () {
         var done = this.async();
+        var self = this;
         this.remote('OmniSharp', 'generator-aspnet', 'release', function (err, remote) {
-                done();
-            }, true);
+            if(err) {
+                self.log.error(err);
+                process.exit(1);
+            }
+            done();
+        }, true);
     },
 
     writing: function () {


### PR DESCRIPTION
This PR introduces basic error handling for Yeoman `remote` fetch future used in application which fails silently on network error.

Instead of seeing this:
```bash
 info ... Fetching https://github.com/OmniSharp/generator-aspnet/archive/release.tar.gz ...
     info This might take a few moments
/Users/piotrblazejewicz/.cache/yeoman


Your project is now created, you can use the following commands to get going
    kpm restore
    kpm build
    k run for console projects
    k kestrel or k webfor web projects
```

the process will now spill error and exit process:
![20150202222604](https://cloud.githubusercontent.com/assets/14539/6009495/863dab02-ab2a-11e4-8205-792a7cbec4f2.jpg)

This is standard solution used in Yeoman projects using remote repository fetching, e.g.:
https://github.com/yeoman/generator-mobile/blob/29c5dbcb947f219c82eca200514788218bf26603/app/index.js#L84-L87

Thanks!