### PR TITLE
Update generator help file content

### DIFF
--- a/app/USAGE
+++ b/app/USAGE
@@ -1,5 +1,3 @@
-  --skip-install # Skip triggering kpm restore automatically  Default: false
-
 Description:
 
   Creates a basic ASP.NET 5 application


### PR DESCRIPTION
This PR removes description of --skip-install from help file. After this change users when typing `--help` will see:
```bash
yo aspnet --help
Usage:
  yo aspnet:app [options] 

Options:
  -h,   --help        # Print generator's options and usage
        --skip-cache  # Do not remember prompt answers       Default: false
        --gulp        # Description for gulp

Description:

  Creates a basic ASP.NET 5 application

Subgenerators: 

  yo aspnet:BowerJson [options]
  yo aspnet:Class [options] <name>
  yo aspnet:CoffeeScript [options] <name>
  yo aspnet:Gruntfile [options] <name>
  yo aspnet:Gulpfile [options] <name>
  yo aspnet:HTMLPage [options] <name>
  yo aspnet:JavaScript [options] <name>
  yo aspnet:JScript [options] <name>
  yo aspnet:JSON [options] <name>
  yo aspnet:MvcController [options] <name>
  yo aspnet:MvcView [options] <name>
  yo aspnet:PackageJson [options]
  yo aspnet:StartupClass [options]
  yo aspnet:TextFile [options] <name>
  yo aspnet:TypeScript [options] <name>
  yo aspnet:WebApiController [options] <name>
```
Thanks!