### PR TITLE
Update README.md generator preview image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Yeoman generator for ASP.NET vNext projects
 
-![](https://cloud.githubusercontent.com/assets/14539/6697962/a57211ac-ccf4-11e4-97d9-7ed16bb16d37.gif)
+[![](https://cloud.githubusercontent.com/assets/14539/6697962/a57211ac-ccf4-11e4-97d9-7ed16bb16d37.gif)](https://github.com/OmniSharp/generator-aspnet 'ASP.NET 5 Generator')
 
 ## Getting Started
 


### PR DESCRIPTION
This PR should fix markup generated by Github.com to point to generator project page. The solution is based on similar syntax used in other projects, e.g.:
https://raw.githubusercontent.com/google/web-starter-kit/master/README.md
Thanks!
