### PR TITLE
Update copyright notice year as project is spanning multiple years

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Produces `filename.ts`
 
 ## License
 
-Copyright 2014 OmniSharp
+Copyright 2014-2015 OmniSharp
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 


### PR DESCRIPTION
The project spans multiple years. This PR updates documentation copyright notice year to reflect that.
The similar approach of marking project span:
https://github.com/twbs/bootstrap/blob/master/README.md#copyright-and-license
The other approach is also possible (the year of the first release only) - so it's up to you guys.

Thanks!