### PR TITLE
Move mocha to development dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,11 @@
   "dependencies": {
     "chai": "^1.10.0",
     "chalk": "~0.4.0",
-    "mocha": "^2.1.0",
     "yeoman-generator": "~0.18.5",
     "yosay": "^0.1.0"
+  },
+  "devDependencies": {
+    "mocha": "^2.2.1"
   },
   "peerDependencies": {
     "yo": ">=1.0.0"


### PR DESCRIPTION
This PR, in order to close #103:
- moves dependency to development time section
- bump Mocha version after tests [side change/can be removed if voted)

After this PR there is a clear distribution of NPM packages:
- dependencies
- development dependencies
- peer dependencies

To develop and test `generator-aspnet` one will have now just to fork repostiory, follow Sayed description and just run NPM install:
```bash
npm install
```
The development time dependency tree will look like:
```bash
tree -d -L 1 node_modules 
node_modules
├── chai
├── chalk
├── mocha
├── yeoman-generator
├── yo
└── yosay
```

I've updated Mocha version, as I simply cleared project NPM modules, removed Mocha dependency, installed it again with `--save-dev` flag and saved modified package file. Then I have run test to be sure we are using non-breaking version:
```bash
npm test

> generator-aspnet@0.0.31 test /Users/piotrblazejewicz/git/generator-aspnet
> mocha



  Subgenerators without arguments tests
    aspnet:PackageJson
      File Creation
[....]
      ✓ nancyTest/Startup.cs created. 
      ✓ nancyTest/HomeModule.cs created. 


  84 passing (805ms)
````
I've checked Mocha release log for any breaking changes (none):
https://github.com/mochajs/mocha/releases

Thanks!