### PR TITLE
Update generator file system IO methods. Closes #107

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -104,124 +104,80 @@ var AspnetGenerator = yeoman.generators.Base.extend({
     },
 
     writing: function () {
-        this.sourceRoot(path.join(__dirname, '../samples/'));
+        this.sourceRoot(path.join(__dirname, './templates/projects'));
 
-        this.mkdir(this.applicationName);
         switch (this.type) {
 
         case 'empty':
-
-            this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
-
-            this.template(this.sourceRoot() + '/startup.cs', this.applicationName + '/Startup.cs',  this.templatedata);
-
-            this.copy(this.sourceRoot() + '/project.json', this.applicationName + '/project.json');
-
+            this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type)); 
+            this.fs.copyTpl(this.templatePath('/startup.cs'), this.destinationPath(this.applicationName + '/Startup.cs'),  this.templatedata);
+            this.fs.copy(this.templatePath('/project.json'), this.destinationPath(this.applicationName + '/project.json'));
             /// wwwroot
-            this.directory(this.sourceRoot() + '/wwwroot', this.applicationName + '/wwwroot');
-
+            this.fs.copy(this.templatePath('/wwwroot'), this.destinationPath(this.applicationName + '/wwwroot'));
             break;
 
         case 'webapi':
             this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
-
-            this.template(this.sourceRoot() + '/startup.cs', this.applicationName + '/Startup.cs',  this.templatedata);
-
-            this.copy(this.sourceRoot() + '/project.json', this.applicationName + '/project.json');
-
-            this.template(this.sourceRoot() + '/controllers_home.cs', this.applicationName + '/Controllers/HomeController.cs',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/controllers_values.cs', this.applicationName + '/Controllers/ValuesController.cs',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/views_home_index.cshtml', this.applicationName + '/Views/Home/Index.cshtml', this.templatedata);
-
+            this.fs.copyTpl(this.templatePath('/startup.cs'), this.destinationPath(this.applicationName + '/Startup.cs'),  this.templatedata);
+            this.fs.copy(this.templatePath('/project.json'), this.destinationPath(this.applicationName + '/project.json'));
+            this.fs.copyTpl(this.templatePath('/controllers_home.cs'), this.destinationPath(this.applicationName + '/Controllers/HomeController.cs'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/controllers_values.cs'), this.destinationPath(this.applicationName + '/Controllers/ValuesController.cs'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/views_home_index.cshtml'), this.destinationPath(this.applicationName + '/Views/Home/Index.cshtml'), this.templatedata);
             /// wwwroot
-            this.directory(this.sourceRoot() + '/wwwroot', this.applicationName + '/wwwroot');
-
+            this.fs.copy(this.templatePath('/wwwroot'), this.destinationPath(this.applicationName + '/wwwroot'));
             break;
 
         case 'web':
             this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
-
-            this.template(this.sourceRoot() + '/startup.cs', this.applicationName + '/Startup.cs',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/bower.json', this.applicationName + '/bower.json',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/config.json', this.applicationName + '/config.json',  this.templatedata);
-
+            this.fs.copyTpl(this.templatePath('/startup.cs'), this.destinationPath(this.applicationName + '/Startup.cs'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/bower.json'), this.destinationPath(this.applicationName + '/bower.json'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/config.json'), this.destinationPath(this.applicationName + '/config.json'),  this.templatedata);
             if (this.options.gulp) {
-                this.copy(this.sourceRoot() + '/_gulp_project.json', this.applicationName + '/project.json');
-
-                this.template(this.sourceRoot() + '/_gulp_package.json', this.applicationName + '/package.json',  this.templatedata);
-
-                this.copy(this.sourceRoot() + '/_gulpfile.js', this.applicationName + '/gulpfile.js');
-
+                this.fs.copy(this.templatePath('/_gulp_project.json'), this.destinationPath(this.applicationName + '/project.json'));
+                this.fs.copyTpl(this.templatePath('/_gulp_package.json'), this.destinationPath(this.applicationName + '/package.json'),  this.templatedata);
+                this.fs.copy(this.templatePath('/_gulpfile.js'), this.destinationPath(this.applicationName + '/gulpfile.js'));
             } else {
-
-                this.copy(this.sourceRoot() + '/_grunt_project.json', this.applicationName + '/project.json');
-
-                this.template(this.sourceRoot() + '/_grunt_package.json', this.applicationName + '/package.json',  this.templatedata);
-
-                this.copy(this.sourceRoot() + '/_gruntfile.js', this.applicationName + '/gruntfile.js');
+                this.fs.copy(this.templatePath('/_grunt_project.json'), this.destinationPath(this.applicationName + '/project.json'));
+                this.fs.copyTpl(this.templatePath('/_grunt_package.json'), this.destinationPath(this.applicationName + '/package.json'),  this.templatedata);
+                this.fs.copy(this.templatePath('/_gruntfile.js'), this.destinationPath(this.applicationName + '/gruntfile.js'));
             }
-
             // models
-            this.template(this.sourceRoot() + '/models_accountview.cs', this.applicationName + '/Models/AccountViewModels.cs',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/models_identity.cs', this.applicationName + '/Models/IdentityModels.cs',  this.templatedata);
-
+            this.fs.copyTpl(this.templatePath('/models_accountview.cs'), this.destinationPath(this.applicationName + '/Models/AccountViewModels.cs'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/models_identity.cs'), this.destinationPath(this.applicationName + '/Models/IdentityModels.cs'),  this.templatedata);
             // controllers
-            this.template(this.sourceRoot() + '/controllers_account.cs', this.applicationName + '/Controllers/AccountController.cs',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/controllers_home.cs', this.applicationName + '/Controllers/HomeController.cs',  this.templatedata);
-
+            this.fs.copyTpl(this.templatePath('/controllers_account.cs'), this.destinationPath(this.applicationName + '/Controllers/AccountController.cs'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/controllers_home.cs'), this.destinationPath(this.applicationName + '/Controllers/HomeController.cs'),  this.templatedata);
             // compiler
-            this.template(this.sourceRoot() + '/compiler_preprocess_razorprecompilation.cs', this.applicationName + '/Compiler/Preprocess/RazorPreCompilation.cs',  this.templatedata);
-
+            this.fs.copyTpl(this.templatePath('/compiler_preprocess_razorprecompilation.cs'), this.destinationPath(this.applicationName + '/Compiler/Preprocess/RazorPreCompilation.cs'),  this.templatedata);
             //migrations
-            this.template(this.sourceRoot() + '/migrations_000000000000000_createidentityschema.cs', this.applicationName + '/Migrations/000000000000000_CreateIdentitySchema.cs',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/migrations_applicationdbcontextmodelsnapshot.cs', this.applicationName + '/Migrations/ApplicationDbContextModelSnapshot.cs',  this.templatedata);
-
+            this.fs.copyTpl(this.templatePath('/migrations_000000000000000_createidentityschema.cs'), this.destinationPath(this.applicationName + '/Migrations/000000000000000_CreateIdentitySchema.cs'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/migrations_applicationdbcontextmodelsnapshot.cs'), this.destinationPath(this.applicationName + '/Migrations/ApplicationDbContextModelSnapshot.cs'),  this.templatedata);
             // views
-            this.template(this.sourceRoot() + '/views_home_contact.cshtml', this.applicationName + '/Views/Home/Contact.cshtml',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/views_home_about.cshtml', this.applicationName + '/Views/Home/About.cshtml',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/views_home_index.cshtml', this.applicationName + '/Views/Home/Index.cshtml',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/views_account_login.cshtml', this.applicationName + '/Views/Account/Login.cshtml',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/views_account_manage.cshtml', this.applicationName + '/Views/Account/Manage.cshtml',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/views_account_register.cshtml', this.applicationName + '/Views/Account/Register.cshtml',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/views_account_changepasswordpartial.cshtml', this.applicationName + '/Views/Account/_ChangePasswordPartial.cshtml',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/views_shared_error.cshtml', this.applicationName + '/Views/Shared/Error.cshtml',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/views_shared_layout.cshtml', this.applicationName + '/Views/Shared/_Layout.cshtml',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/views_shared_loginpartial.cshtml', this.applicationName + '/Views/Shared/_LoginPartial.cshtml',  this.templatedata);
-
-            this.template(this.sourceRoot() + '/views_viewstart.cshtml', this.applicationName + '/Views/_ViewStart.cshtml',  this.templatedata);
-
+            this.fs.copyTpl(this.templatePath('/views_home_contact.cshtml'), this.destinationPath(this.applicationName + '/Views/Home/Contact.cshtml'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/views_home_about.cshtml'), this.destinationPath(this.applicationName + '/Views/Home/About.cshtml'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/views_home_index.cshtml'), this.destinationPath(this.applicationName + '/Views/Home/Index.cshtml'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/views_account_login.cshtml'), this.destinationPath(this.applicationName + '/Views/Account/Login.cshtml'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/views_account_manage.cshtml'), this.destinationPath(this.applicationName + '/Views/Account/Manage.cshtml'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/views_account_register.cshtml'), this.destinationPath(this.applicationName + '/Views/Account/Register.cshtml'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/views_account_changepasswordpartial.cshtml'), this.destinationPath(this.applicationName + '/Views/Account/_ChangePasswordPartial.cshtml'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/views_shared_error.cshtml'), this.destinationPath(this.applicationName + '/Views/Shared/Error.cshtml'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/views_shared_layout.cshtml'), this.destinationPath(this.applicationName + '/Views/Shared/_Layout.cshtml'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/views_shared_loginpartial.cshtml'), this.destinationPath(this.applicationName + '/Views/Shared/_LoginPartial.cshtml'),  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/views_viewstart.cshtml'), this.destinationPath(this.applicationName + '/Views/_ViewStart.cshtml'),  this.templatedata);
             /// wwwroot
-            this.directory(this.sourceRoot() + '/wwwroot', this.applicationName + '/wwwroot');
+            this.directory(this.templatePath('/wwwroot'), this.destinationPath(this.applicationName + '/wwwroot'));
             break;
         case 'nancy':
             this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
-
-            this.template(this.sourceRoot() + '/startup.cs', this.applicationName + '/Startup.cs',  this.templatedata);
-
-            this.copy(this.sourceRoot() + '/project.json', this.applicationName + '/project.json');
-
-            this.template(this.sourceRoot() + '/homemodule.cs', this.applicationName + '/HomeModule.cs',  this.templatedata);
+            this.fs.copyTpl(this.templatePath('/startup.cs'), this.destinationPath(this.applicationName + '/Startup.cs'),  this.templatedata);
+            this.fs.copy(this.templatePath('/project.json'), this.destinationPath(this.applicationName + '/project.json'));
+            this.fs.copyTpl(this.templatePath('/homemodule.cs'), this.destinationPath(this.applicationName + '/HomeModule.cs'),  this.templatedata);
             break;
         case 'console':
         case 'classlib':
         case 'unittest':
-            this.directory(this.type, this.applicationName);
+            this.sourceRoot(path.join(__dirname, '../samples'));
+            this.fs.copy(this.templatePath(this.type), this.destinationPath(this.applicationName));
             break;
         default:
             this.log('Unknown project type');

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
   ],
   "dependencies": {
     "chai": "^1.10.0",
-    "chalk": "~0.4.0",
-    "yeoman-generator": "~0.18.5",
-    "yosay": "^0.1.0"
+    "chalk": "^1.0.0",
+    "yeoman-generator": "^0.19.0",
+    "yosay": "^1.0.0"
   },
   "devDependencies": {
     "mocha": "^2.2.1"

--- a/script-base-basic.js
+++ b/script-base-basic.js
@@ -6,17 +6,13 @@ var chalk = require('chalk');
 
 var Generator = module.exports = function Generator() {
   yeoman.generators.Base.apply(this, arguments);
-
-  var sourceRoot = '/templates/';
-  this.sourceRoot(path.join(__dirname, sourceRoot));
+  this.sourceRoot(path.join(__dirname, './templates/'));
 }; 
 
 util.inherits(Generator, yeoman.generators.Base);
 
-Generator.prototype.generateStandardFile = function(sourceFile, targetFile){
-   this.log('You called the aspnet subgenerator with the arg ' + sourceFile);
-
-  this.src.copy(sourceFile, targetFile);
-
+Generator.prototype.generateStandardFile = function(sourceFile, targetFile) {
+  this.log('You called the aspnet subgenerator with the arg ' + sourceFile);
+  this.fs.copy(this.templatePath(sourceFile), this.destinationPath(targetFile));
   this.log(targetFile + ' created.')
 }

--- a/script-base.js
+++ b/script-base.js
@@ -6,21 +6,17 @@ var chalk = require('chalk');
 
 var NamedGenerator = module.exports = function NamedGenerator() {
     yeoman.generators.NamedBase.apply(this, arguments);
-
-    var sourceRoot = '/templates/';
-    this.sourceRoot(path.join(__dirname, sourceRoot));
+    this.sourceRoot(path.join(__dirname, './templates/'));
 };
 
 util.inherits(NamedGenerator, yeoman.generators.NamedBase);
 
 NamedGenerator.prototype.generateTemplateFile = function (templateFile, targetFile, templateData) {
     this.log('You called the aspnet subgenerator with the arg ' + this.name);
-
     if (templateData !== null) {
-        this.template(templateFile, targetFile, templateData);
+        this.fs.copyTpl(this.templatePath(templateFile), this.destinationPath(targetFile), templateData);
     } else {
-        this.template(templateFile, targetFile);
+        this.fs.copyTpl(this.templatePath(templateFile), this.destinationPath(targetFile));
     }
-
     this.log(targetFile + ' created.')
 }

--- a/test/test-utility.js
+++ b/test/test-utility.js
@@ -12,7 +12,6 @@ var util = (function () {
             mockGen = yeoman.test;
 
             mockGen.run(path.join(__dirname, '../' + subgenerator))
-                .inDir(path.join(__dirname, './.tmp'))
                 .on('end', done);
         });
     };
@@ -23,7 +22,6 @@ var util = (function () {
             mockGen = yeoman.test;
 
             mockGen.run(path.join(__dirname, '../' + subgenerator))
-                .inDir(path.join(__dirname, './.tmp'))
                 .withArguments(args)
                 .on('end', done);
         });
@@ -43,10 +41,8 @@ var util = (function () {
             };
 
             mockGen.run(path.join(__dirname, '../app'))
-
-            .inDir(path.join(__dirname, './.tmp'))
-                .withPrompt(mockPrompt)
-                .on('end', done);
+              .withPrompts(mockPrompt)
+              .on('end', done);
         });
 
     };
@@ -63,11 +59,9 @@ var util = (function () {
             };
 
             mockGen.run(path.join(__dirname, '../app'))
-
-            .inDir(path.join(__dirname, './.tmp'))
-                .withPrompt(mockPrompt)
-                .withOptions(options)
-                .on('end', done);
+              .withPrompts(mockPrompt)
+              .withOptions(options)
+              .on('end', done);
         });
 
     };


### PR DESCRIPTION
Hello,

As reported on: https://github.com/OmniSharp/generator-aspnet/issues/107

This commit replace file system touching operations with
Yeoman's wrapper around mem-fs module as advised by Yeoman's documentation.
The commit removes use of already deprecated api, use this.fs module wrapper
and fixes problem with relative paths used in base class.
Tested with both npm test and current e2e test
The npm test have been failing - unless I rewrote implementation in base generate to use `this.templatePath` and `this.destinationPath` as per current docs.

Tests run locally are OK (`84 passing (739ms)` etc), but I've run them only on OS X machine.

http://yeoman.io/authoring/file-system.html

@sayedihashimi @spboyer Can you guys review this PR and test on other OS? (I'll try to verify on Windows OS at my work, but can't promise :) )

Thanks!