### PR TITLE
Remove Yo from peerDependencies. Closes #118

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,6 @@
   "devDependencies": {
     "mocha": "^2.2.1"
   },
-  "peerDependencies": {
-    "yo": ">=1.0.0"
-  },
   "scripts": {
     "test": "mocha"
   }


### PR DESCRIPTION
The commit remove Yo as peer dependency of generator.
The reason of this commit is to not show warnings about generators
to end users in recent version of NPM during generator installation.
The final decision about exact peerDependencies is not yet know, but
removing it won't hurt generator itself and left users with less warnings
and outputs from install routine(s).

Similar commit in `generator-generator`:
https://github.com/yeoman/generator-generator/commit/14d39bc78a675742e5590b769a8d527fba81fa1f

The discussion about `peerDependencies` and its current state in NPM:
https://github.com/npm/npm/issues/6565

Thanks!