### PR TITLE
Add test for .gitignore subgenerator

### DIFF
--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -29,6 +29,11 @@ describe('Subgenerators without arguments tests', function () {
         util.goCreate('StartupClass');
         util.fileCheck('should create Startup.cs file', 'Startup.cs');
     });
+
+    describe('aspnet:gitignore', function () {
+        util.goCreate('gitignore');
+        util.fileCheck('should create .gitignore file', '.gitignore');
+    });
 });
 
 /*


### PR DESCRIPTION
This commit add test-case for .gitignore file creation.
The PR should be only merged if #127 is merged

If tested locally via `npm test` before merging #127, it will break tests:
```
    aspnet:StartupClass
      File Creation
        ✓ should create Startup.cs file
    aspnet:gitignore
      1) "before all" hook

  5 passing (204ms)
  1 failing
```
However, if tested after changes added via #127  it will pass:
```
  Subgenerators without arguments tests
    aspnet:PackageJson
      File Creation
        ✓ should create package json file
    aspnet:Gulpfile
      File Creation
        ✓ should create gulp file
    aspnet:BowerJson
      File Creation
        ✓ should create bower file
    aspnet:Config
      File Creation
        ✓ should create config json file
    aspnet:StartupClass
      File Creation
        ✓ should create Startup.cs file
    aspnet:gitignore
      File Creation
        ✓ should create .gitignore file
```

Thanks!