### PR TITLE
Add missing quotes in JSHint config

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,14 +1,14 @@
 {
-node: true,
-esnext: true,
-bitwise: true,
-camelcase: true,
-curly: true,
-immed: true,
-newcap: true,
-noarg: true,
-undef: true,
-unused: "vars",
-strict: true,
-mocha: true
+  "node": true,
+  "esnext": true,
+  "bitwise": true,
+  "camelcase": true,
+  "curly": true,
+  "immed": true,
+  "newcap": true,
+  "noarg": true,
+  "undef": true,
+  "unused": "vars",
+  "strict": true,
+  "mocha": true
 }


### PR DESCRIPTION
The quotes were stripped somehow from original source:

![image](https://cloud.githubusercontent.com/assets/14539/7422080/26402bf4-ef8a-11e4-8eff-d45194e34b6e.png)

https://github.com/yeoman/generator-generator/blob/master/app/templates/jshintrc

Thanks!