### PR TITLE
Add missing strict statement: #E007

### DIFF
--- a/JavaScript/index.js
+++ b/JavaScript/index.js
@@ -1,1 +1,3 @@
+'use strict';
+
 module.exports = require('../JScript');

--- a/templates/gruntfile.js
+++ b/templates/gruntfile.js
@@ -2,6 +2,8 @@
 This file is the main entry point for defining grunt tasks and using grunt plugins.
 Click here to learn more. http://go.microsoft.com/fwlink/?LinkID=513275&clcid=0x409
 */
+'use strict';
+
 module.exports = function (grunt) {
     grunt.initConfig({
     });

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -1,3 +1,4 @@
+'use strict';
 var util = require('./test-utility');
 
 /*

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -1,3 +1,4 @@
+'use strict';
 var yeoman = require('yeoman-generator');
 var path = require('path');
 var mockGen;
@@ -30,7 +31,7 @@ describe('aspnet - Empty Application', function() {
 
   var files = ['emptyTest/project.json', 'emptyTest/Startup.cs'];
   describe('Checking files', function() {
-    for (i = 0; i < files.length; i++) {
+    for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
   });
@@ -52,7 +53,7 @@ describe('aspnet - Class Library', function() {
 
   var files = ['classTest/project.json', 'classTest/Class1.cs', 'classTest/.gitignore'];
   describe('Checking files', function() {
-    for (i = 0; i < files.length; i++) {
+    for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
   });
@@ -75,7 +76,7 @@ describe('aspnet - Console Application', function() {
 
   var files = ['consoleTest/project.json', 'consoleTest/Program.cs', 'consoleTest/.gitignore'];
   describe('Checking files', function() {
-    for (i = 0; i < files.length; i++) {
+    for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
   });
@@ -97,7 +98,7 @@ describe('aspnet - Unit Test Application', function() {
 
   var files = ['unittestTest/project.json', 'unittestTest/SampleTest.cs'];
   describe('Checking files', function() {
-    for (i = 0; i < files.length; i++) {
+    for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
   });
@@ -255,7 +256,7 @@ describe('aspnet - Web Application', function() {
     'webTest/Migrations/ApplicationDbContextModelSnapshot.cs'
   ];
   describe('Checking files', function() {
-    for (i = 0; i < files.length; i++) {
+    for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
   });
@@ -283,7 +284,7 @@ describe('aspnet - Web API Application', function() {
 
   var files = ['webAPITest/project.json', 'webAPITest/Startup.cs', 'webAPITest/Controllers/ValuesController.cs'];
   describe('Checking files', function() {
-    for (i = 0; i < files.length; i++) {
+    for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
   });
@@ -307,7 +308,7 @@ describe('aspnet - Nancy Application', function() {
 
   var files = ['nancyTest/project.json', 'nancyTest/Startup.cs', 'nancyTest/HomeModule.cs'];
   describe('Checking files', function() {
-    for (i = 0; i < files.length; i++) {
+    for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
   });

--- a/test/test-utility.js
+++ b/test/test-utility.js
@@ -1,3 +1,4 @@
+'use strict';
 var util = (function() {
 
   var yeoman = require('yeoman-generator');
@@ -69,7 +70,7 @@ var util = (function() {
   function dirsCheck(dirs) {
     describe('Directories Creation', function() {
 
-      for (i = 0; i < dirs.length; i++) {
+      for (var i = 0; i < dirs.length; i++) {
         it(dirs[i] + ' created.', function() {
           assert.file(dirs[i]);
         });


### PR DESCRIPTION
This commit add missing 'use strict' statements to source code as strict mode
usage is mandated by .jshintrc config file in project.
The commit also adds missing variable declarations to loops in tests suite - as
using strict mode resulted in immediate runtime errors from these loops: 'ReferenceError: i is not defined'. So this commit also covers fixing that missing variable declarations.

Thanks!