### PR TITLE
Update Class Library project template for beta5

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -228,7 +228,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
 
         this.template(this.sourceRoot() + '/class.cs', this.applicationName + '/Class1.cs', this.templatedata);
 
-        this.copy(this.sourceRoot() + '/project.json', this.applicationName + '/project.json');
+        this.template(this.sourceRoot() + '/project.json', this.applicationName + '/project.json', this.templatedata);
 
         break;
       case 'unittest':

--- a/templates/projects/classlib/class.cs
+++ b/templates/projects/classlib/class.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace <%= namespace %>
 {
@@ -6,7 +9,6 @@ namespace <%= namespace %>
     {
         public Class1()
         {
-
         }
     }
 }

--- a/templates/projects/classlib/project.json
+++ b/templates/projects/classlib/project.json
@@ -1,15 +1,19 @@
 {
-    "version": "1.0.0-*",
-    "dependencies": {},
+  "version": "1.0.0-*",
+  "description": "<%= namespace %> Class Library",
+  "tags": [""],
+  "projectUrl": "",
+  "licenseUrl": "",
 
-    "frameworks": {
-        "dnx451": {
-            "dependencies": {}
-        },
-        "dnxcore50": {
-            "dependencies": {
-                "System.Runtime": "4.0.20-*"
-            }
-        }
-    }
+  "dependencies": {
+    "System.Collections": "4.0.10-beta-23015",
+    "System.Linq": "4.0.0-beta-23015",
+    "System.Threading": "4.0.10-beta-23015",
+    "Microsoft.CSharp": "4.0.0-beta-23015",
+    "System.Runtime": "4.0.20-beta-23015"
+  },
+
+  "frameworks": {
+    "dotnet": {}
+  }
 }


### PR DESCRIPTION
This PR updates:
- generator Class Library task switching to template when creating class file
- update code and its structure of generate class to content from beta5
- update project file to content and structure from beta5
The content is based on example files via @rustd

The change passes `npm test` and once project is created it builds and restores correctly under my OmniSharp Atom plugin.