### PR TITLE
Update Console application project template for beta5

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -218,7 +218,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
 
         this.template(this.sourceRoot() + '/program.cs', this.applicationName + '/Program.cs', this.templatedata);
 
-        this.copy(this.sourceRoot() + '/project.json', this.applicationName + '/project.json');
+        this.template(this.sourceRoot() + '/project.json', this.applicationName + '/project.json', this.templatedata);
 
         break;
       case 'classlib':

--- a/templates/projects/console/program.cs
+++ b/templates/projects/console/program.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace <%= namespace %>
 {
     public class Program
     {
-        public static void Main(string[] args)
+        public void Main(string[] args)
         {
             Console.WriteLine("Hello World");
             Console.ReadLine();

--- a/templates/projects/console/project.json
+++ b/templates/projects/console/project.json
@@ -1,15 +1,26 @@
 {
-    "version": "1.0.0-*",
-    "dependencies": {},
-    "commands": {
-        "run": "run"
-    },
-    "frameworks": {
-        "dnx451": {},
-        "dnxcore50": {
-            "dependencies": {
-                "System.Console": "4.0.0-beta-*"
-            }
-        }
+  "version": "1.0.0-*",
+  "description": "<%= namespace %> Console Application",
+  "tags": [""],
+  "projectUrl": "",
+  "licenseUrl": "",
+
+  "dependencies": {},
+
+  "commands": {
+    "run": "run"
+  },
+
+  "frameworks": {
+    "dnx451": {},
+    "dnxcore50": {
+      "dependencies": {
+        "System.Collections": "4.0.10-beta-23015",
+        "System.Linq": "4.0.0-beta-23015",
+        "System.Threading": "4.0.10-beta-23015",
+        "Microsoft.CSharp": "4.0.0-beta-23015",
+        "System.Console": "4.0.0-beta-23015"
+      }
     }
+  }
 }


### PR DESCRIPTION
This commit introduces following changes:
- project file is create with template routine to update project name
according to one chosen by user
- the content and structure of console program is based on beta5 example
- the example console output is left from existing code to let user know that
applicaiton is correctly build and run
The content of changes is based on beta5 examples via @rustd

The update passes `npm test` and create content can be succesfully run on OS X (but I can't yet bullet proof it againts beta5, etc)