### PR TITLE
Ignore project lock file(s) artifacts in project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .npmignore
 .tmp
 typings
+**/project.lock.json


### PR DESCRIPTION
This commit adds project.lock.json entry to project own .gitignore file
to prevent tracking accidentaly created by `dnu restore` project locker

The entry is any-level deep mask, so it will work when project content is authored for example in `templates` directory.
On several occasion my OmniSharp plugin in Atom editor started restore build and project locker files were created. This commit will prevent from tracking them during project development.

This PR starts from master (to avoid confusion with beta5 branch)