### PR TITLE
Update WebApiController template for beta5

### DIFF
--- a/WebApiController/index.js
+++ b/WebApiController/index.js
@@ -8,10 +8,12 @@ var NamedGenerator = module.exports = function NamedGenerator() {
 
 util.inherits(NamedGenerator, ScriptBase);
 
-NamedGenerator.prototype.createNamedItem = function(){
-	this.generateTemplateFile(
-		'apicontroller.cs',
-		this.name + '.cs',
-		{ namespace: 'MyNamespace', classname: this.name }	
-	);
+NamedGenerator.prototype.createNamedItem = function() {
+  this.generateTemplateFile(
+    'WebApiController.cs',
+    this.name + '.cs', {
+      namespace: 'MyNamespace',
+      classname: this.name
+    }
+  );
 };

--- a/templates/WebApiController.cs
+++ b/templates/WebApiController.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNet.Mvc;
 
-namespace <%= namespace %>.Controllers
+// For more information on enabling Web API for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
+
+namespace <%= namespace %>
 {
     [Route("api/[controller]")]
     public class <%= classname %> : Controller


### PR DESCRIPTION
- review code changes
- code refactor and whitespace fixes
- update template name to be consistent with subgenerator name (`apicontroller` -> `WebApiController`)

Thanks!