### PR TITLE
Add missing closing for x-ua-compatible tag in websimple template.

### DIFF
--- a/templates/projects/websimple/Views/Shared/_Layout.cshtml
+++ b/templates/projects/websimple/Views/Shared/_Layout.cshtml
@@ -2,7 +2,7 @@
 <html lang="">
     <head>
         <meta charset="utf-8" />
-        <meta http-equiv="x-ua-compatible" content="ie=edge"
+        <meta http-equiv="x-ua-compatible" content="ie=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>@ViewData["Title"] - <%= namespace %></title>
 
@@ -13,7 +13,7 @@
         </environment>
         <environment names="Staging,Production">
             <link rel="stylesheet" href="//ajax.aspnetcdn.com/ajax/bootstrap/3.0.0/css/bootstrap.min.css"
-                  asp-fallback-href="~/lib/bootstrap/css/bootstrap.min.css"
+                  asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
                   asp-fallback-test-class="hidden" asp-fallback-test-property="visibility" asp-fallback-test-value="hidden" />
             <link rel="stylesheet" href="//ajax.aspnetcdn.com/ajax/bootstrap-touch-carousel/0.8.0/css/bootstrap-touch-carousel.css"
                   asp-fallback-href="~/lib/bootstrap-touch-carousel/css/bootstrap-touch-carousel.css"


### PR DESCRIPTION
Also fix production bootstrap css file fallback path in same template.