### PR TITLE
Add Gruntfile for the Web Application Simple project template.

### DIFF
--- a/templates/projects/websimple/gruntfile.js
+++ b/templates/projects/websimple/gruntfile.js
@@ -1,0 +1,23 @@
+// This file in the main entry point for defining grunt tasks and using grunt plugins.
+// Click here to learn more. http://go.microsoft.com/fwlink/?LinkID=513275&clcid=0x409
+module.exports = function(grunt) {
+  'use strict';
+  grunt.initConfig({
+    bower: {
+      install: {
+        options: {
+          targetDir: "wwwroot/lib",
+          layout: "byComponent",
+          cleanTargetDir: false
+        }
+      }
+    }
+  });
+
+  // This command registers the default task which will install bower packages into wwwroot/lib
+  grunt.registerTask("default", ["bower:install"]);
+
+  // The following line loads the grunt plugins.
+  // This line needs to be at the end of this this file.
+  grunt.loadNpmTasks("grunt-bower-task");
+};


### PR DESCRIPTION
Fixes error about missing source file when using the --grunt option on the Web Application Simple template.