### PR TITLE
Fix unclosed meta tag

### DIFF
--- a/templates/projects/websimple/Views/Shared/_Layout.cshtml
+++ b/templates/projects/websimple/Views/Shared/_Layout.cshtml
@@ -2,7 +2,7 @@
 <html lang="">
     <head>
         <meta charset="utf-8" />
-        <meta http-equiv="x-ua-compatible" content="ie=edge"
+        <meta http-equiv="x-ua-compatible" content="ie=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>@ViewData["Title"] - <%= namespace %></title>
 


### PR DESCRIPTION
This commit fixes unclosed meta tag, which was part of previous #248.
The unclosed tag is still a bug, a needs to be fixed:
https://validator.w3.org/docs/errors.html

Thanks!