### PR TITLE
:shirt: Fix JSHint linter errors

### DIFF
--- a/test/test-core.js
+++ b/test/test-core.js
@@ -10,8 +10,8 @@ describe('aspnet 5 generator', function() {
   it('can be imported', function() {
     var app = require('../app');
     yeoman.assert.notEqual(app, undefined);
-  })
-})
+  });
+});
 
 
 /*

--- a/test/test-utility.js
+++ b/test/test-utility.js
@@ -69,8 +69,8 @@ var util = (function() {
 
   function dirsCheck(dirs) {
     describe('Directories Creation', function() {
-
       for (var i = 0; i < dirs.length; i++) {
+        /*jshint loopfunc: true */
         it(dirs[i] + ' created.', function() {
           assert.file(dirs[i]);
         });
@@ -87,7 +87,7 @@ var util = (function() {
       assert.file(file);
     });
 
-  };
+  }
 
   function dirCheck(message, dir) {
     describe('Directory Creation', function() {


### PR DESCRIPTION
Cleanup PR - it fixes JSHint errors based on current .jshintrc settings:
- missing semicolons
- unnecessary semicolon
- exemption added for no-function within a loop rule

Thanks!

