### PR TITLE
fixing where .gitignore is created for webapi project

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -127,7 +127,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
 
       case 'webapi':
         this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
-        this.fs.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '.gitignore');
+        this.fs.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '/.gitignore');
         this.fs.copy(this.sourceRoot() + '/hosting.ini', this.applicationName + '/hosting.ini');
         this.fs.copyTpl(this.sourceRoot() + '/Startup.cs', this.applicationName + '/Startup.cs', this.templatedata);
         this.fs.copy(this.sourceRoot() + '/project.json', this.applicationName + '/project.json');

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -409,6 +409,7 @@ describe('aspnet - Web API Application', function() {
     'webAPITest/project.json',
     'webAPITest/Properties/launchSettings.json',
     'webAPITest/Startup.cs',
+    'webAPITest/.gitignore',
     'webAPITest/wwwroot/README.md'
   ];
   describe('Checking files', function() {


### PR DESCRIPTION
Fixing the issue where the .gitignore file was being created in the same directory as the project folder and not inside of it.