### PR TITLE
Add description for --grunt option in help.  Closes #244.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -10,7 +10,9 @@ var AspnetGenerator = yeoman.generators.Base.extend({
     yeoman.generators.Base.apply(this, arguments);
     // only implemented for web template
     this.option('grunt', {
-      desc: 'Generates a Gruntfile.js file for web templates instead of gulp.js'
+      type: Boolean,
+      defaults: false,
+      desc: 'Use the Grunt JavaScript task runner instead of Gulp in web projects.'
     });
   },
 

--- a/app/index.js
+++ b/app/index.js
@@ -9,7 +9,9 @@ var AspnetGenerator = yeoman.generators.Base.extend({
   constructor: function() {
     yeoman.generators.Base.apply(this, arguments);
     // only implemented for web template
-    this.option('grunt');
+    this.option('grunt', {
+      desc: 'Generates a Gruntfile.js file for web templates instead of gulp.js'
+    });
   },
 
 


### PR DESCRIPTION
Output should now be:

    λ yo aspnet --help
    Usage:
      yo aspnet:app [options]
    
    Options:
      -h,   --help# Print the generator's options and usage
    --skip-cache  # Do not remember prompt answers  Default: false
    --grunt   # Generates a Gruntfile.js file for web templates instead of gulp.js