### PR TITLE
Use SPDX license identifier. Closes #263

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "generator-aspnet",
   "version": "0.0.50",
   "description": "Yeoman generator for ASP.NET 5 apps",
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "main": "app/index.js",
   "repository": "OmniSharp/generator-aspnet",
   "contributors": [


### PR DESCRIPTION
This commit uses SPDX identifier for Apache 2.0 license as
imposed by current NPM documentation. Verified with other
NPM registered packages with the same license.
https://spdx.org/licenses/
https://docs.npmjs.com/files/package.json#license

Thanks!