### PR TITLE
White spaces fixes and linter warnings removal

### DIFF
--- a/Class/index.js
+++ b/Class/index.js
@@ -3,16 +3,17 @@ var util = require('util');
 var ScriptBase = require('../script-base.js');
 
 var NamedGenerator = module.exports = function NamedGenerator() {
-	ScriptBase.apply(this, arguments);
+  ScriptBase.apply(this, arguments);
 };
 
 util.inherits(NamedGenerator, ScriptBase);
 
-NamedGenerator.prototype.createNamedItem = function(){
-	this.generateTemplateFile(
-		'class.cs',
-		this.name + '.cs',
-		{ namespace: 'MyNamespace', classname: this.name }	
-	);
+NamedGenerator.prototype.createNamedItem = function() {
+  this.generateTemplateFile(
+    'class.cs',
+    this.name + '.cs', {
+      namespace: 'MyNamespace',
+      classname: this.name
+    }
+  );
 };
-

--- a/Config/index.js
+++ b/Config/index.js
@@ -3,13 +3,11 @@ var util = require('util');
 var ScriptBase = require('../script-base-basic.js');
 
 var Generator = module.exports = function Generator() {
-	ScriptBase.apply(this, arguments);
+  ScriptBase.apply(this, arguments);
 };
 
 util.inherits(Generator, ScriptBase);
 
-Generator.prototype.createItem = function(){
-	this.generateStandardFile('config.json', 'config.json');
+Generator.prototype.createItem = function() {
+  this.generateStandardFile('config.json', 'config.json');
 };
-
-

--- a/Gulpfile/index.js
+++ b/Gulpfile/index.js
@@ -3,13 +3,11 @@ var util = require('util');
 var ScriptBase = require('../script-base-basic.js');
 
 var Generator = module.exports = function Generator() {
-	ScriptBase.apply(this, arguments);
+  ScriptBase.apply(this, arguments);
 };
 
 util.inherits(Generator, ScriptBase);
 
-Generator.prototype.createItem = function(){
-	this.generateStandardFile('gulpfile.js', 'gulpfile.js');
+Generator.prototype.createItem = function() {
+  this.generateStandardFile('gulpfile.js', 'gulpfile.js');
 };
-
-

--- a/PackageJson/index.js
+++ b/PackageJson/index.js
@@ -3,13 +3,11 @@ var util = require('util');
 var ScriptBase = require('../script-base-basic.js');
 
 var Generator = module.exports = function Generator() {
-	ScriptBase.apply(this, arguments);
+  ScriptBase.apply(this, arguments);
 };
 
 util.inherits(Generator, ScriptBase);
 
-Generator.prototype.createItem = function(){
-	this.generateStandardFile('package.json', 'package.json');
+Generator.prototype.createItem = function() {
+  this.generateStandardFile('package.json', 'package.json');
 };
-
-

--- a/StartupClass/index.js
+++ b/StartupClass/index.js
@@ -3,11 +3,11 @@ var util = require('util');
 var ScriptBase = require('../script-base-basic');
 
 var Generator = module.exports = function Generator() {
-	ScriptBase.apply(this, arguments);
+  ScriptBase.apply(this, arguments);
 };
 
 util.inherits(Generator, ScriptBase);
 
-Generator.prototype.createItem = function(){
-	this.generateStandardFile('Startup.cs', 'Startup.cs');
+Generator.prototype.createItem = function() {
+  this.generateStandardFile('Startup.cs', 'Startup.cs');
 };

--- a/TypeScriptConfig/index.js
+++ b/TypeScriptConfig/index.js
@@ -3,11 +3,11 @@ var util = require('util');
 var ScriptBase = require('../script-base-basic.js');
 
 var Generator = module.exports = function Generator() {
-	ScriptBase.apply(this, arguments);
+  ScriptBase.apply(this, arguments);
 };
 
 util.inherits(Generator, ScriptBase);
 
-Generator.prototype.createItem = function(){
-	this.generateStandardFile('tsconfig.json', 'tsconfig.json');
+Generator.prototype.createItem = function() {
+  this.generateStandardFile('tsconfig.json', 'tsconfig.json');
 };

--- a/WebApiController/index.js
+++ b/WebApiController/index.js
@@ -3,7 +3,7 @@ var util = require('util');
 var ScriptBase = require('../script-base.js');
 
 var NamedGenerator = module.exports = function NamedGenerator() {
-	ScriptBase.apply(this, arguments);
+  ScriptBase.apply(this, arguments);
 }
 
 util.inherits(NamedGenerator, ScriptBase);

--- a/WebApiController/index.js
+++ b/WebApiController/index.js
@@ -4,7 +4,7 @@ var ScriptBase = require('../script-base.js');
 
 var NamedGenerator = module.exports = function NamedGenerator() {
   ScriptBase.apply(this, arguments);
-}
+};
 
 util.inherits(NamedGenerator, ScriptBase);
 

--- a/app/index.js
+++ b/app/index.js
@@ -31,31 +31,30 @@ var AspnetGenerator = yeoman.generators.Base.extend({
       name: 'type',
       message: 'What type of application do you want to create?',
       choices: [{
-          name: 'Empty Application',
-          value: 'empty'
-        }, {
-          name: 'Console Application',
-          value: 'console'
-        }, {
-          name: 'Web Application',
-          value: 'web'
-        }, {
-          name: 'Web Application Basic [without Membership and Authorization]',
-          value: 'webbasic'
-        }, {
-          name: 'Web API Application',
-          value: 'webapi'
-        }, {
-          name: 'Nancy ASP.NET Application',
-          value: 'nancy'
-        }, {
-          name: 'Class Library',
-          value: 'classlib'
-        },
-        {
-           name: 'Unit test project',
-           value: 'unittest'
-        }
+            name: 'Empty Application',
+            value: 'empty'
+          }, {
+            name: 'Console Application',
+            value: 'console'
+          }, {
+            name: 'Web Application',
+            value: 'web'
+          }, {
+            name: 'Web Application Basic [without Membership and Authorization]',
+            value: 'webbasic'
+          }, {
+            name: 'Web API Application',
+            value: 'webapi'
+          }, {
+            name: 'Nancy ASP.NET Application',
+            value: 'nancy'
+          }, {
+            name: 'Class Library',
+            value: 'classlib'
+          }, {
+            name: 'Unit test project',
+            value: 'unittest'
+          }
       ]
     }];
 

--- a/gitignore/index.js
+++ b/gitignore/index.js
@@ -3,11 +3,11 @@ var util = require('util');
 var ScriptBase = require('../script-base-basic.js');
 
 var Generator = module.exports = function Generator() {
-    ScriptBase.apply(this, arguments);
+  ScriptBase.apply(this, arguments);
 };
 
 util.inherits(Generator, ScriptBase);
 
-Generator.prototype.createItem = function () {
-    this.generateStandardFile('gitignore.txt', '.gitignore');
+Generator.prototype.createItem = function() {
+  this.generateStandardFile('gitignore.txt', '.gitignore');
 };

--- a/test/compat.js
+++ b/test/compat.js
@@ -1,6 +1,4 @@
 'use strict';
-var yeoman = require('yeoman-generator');
-var assert = yeoman.assert;
 var util = require('./test-utility');
 
 /*

--- a/test/compat.js
+++ b/test/compat.js
@@ -7,7 +7,6 @@ var util = require('./test-utility');
  * Check that namespace is normalized.
  */
 describe('compat - namespace normalization', function() {
-
   util.goCreateApplication('classlib', 'name-test');
   util.fileContentCheck('name-test/Class1.cs', 'namespace normalized', /^namespace name_test$/m);
 });


### PR DESCRIPTION
As beta6 is merged to master this PR quickly unifies project source code whitespace according to project `.editorconfig` rules and removes JSHint linter errors/warnings as detected per project `.jshintrc` settings.
The commits were tested with `npm test`.

Thanks!