### PR TITLE
Add missing site.js dev script reference to _layout.cshtml

### DIFF
--- a/templates/projects/webbasic/Views/Shared/_Layout.cshtml
+++ b/templates/projects/webbasic/Views/Shared/_Layout.cshtml
@@ -53,6 +53,7 @@
             <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
             <script src="~/lib/hammer.js/hammer.js"></script>
             <script src="~/lib/bootstrap-touch-carousel/dist/js/bootstrap-touch-carousel.js"></script>
+            <script src="~/js/site.js"></script>
         </environment>
         <environment names="Staging,Production">
             <script src="//ajax.aspnetcdn.com/ajax/jquery/jquery-2.1.4.min.js"


### PR DESCRIPTION
`_layout.cshtml` is missing a reference to `~/js/site.js` when run in development mode.