### PR TITLE
Add missing development script import.

### DIFF
--- a/templates/projects/web/Views/Shared/_Layout.cshtml
+++ b/templates/projects/web/Views/Shared/_Layout.cshtml
@@ -54,6 +54,7 @@
             <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
             <script src="~/lib/hammer.js/hammer.js"></script>
             <script src="~/lib/bootstrap-touch-carousel/dist/js/bootstrap-touch-carousel.js"></script>
+            <script src="~/js/site.js"></script>
         </environment>
         <environment names="Staging,Production">
             <script src="//ajax.aspnetcdn.com/ajax/jquery/jquery-2.1.4.min.js"


### PR DESCRIPTION
The Web application template is missing site.js import exactly
as in #300 which fixed this problem in Web Basic application template.
This commit adds missing script import

Tested at runtime with `--ASPNET_ENV Development` settings.

Thanks!