### PR TITLE
Correct white space in template project

### DIFF
--- a/templates/projects/webbasic/project.json
+++ b/templates/projects/webbasic/project.json
@@ -42,7 +42,7 @@
   "scripts": {
     "prepublish": [
       "npm install",
-      "bower install", <% if(!grunt){ %>
+      "bower install",<% if(!grunt){ %>
       "gulp clean",
       "gulp min"<% } %><% if(grunt){ %>
       "grunt default"


### PR DESCRIPTION
This is trivial change, it removes extra white space from generated `project.json` file. It applies only to `Web Application Basic` template file.
Tested with mocha and with generated project.
Thanks!