### PR TITLE
Update WebAPI template for beta7. Closes #315

### DIFF
--- a/templates/projects/webapi/project.json
+++ b/templates/projects/webapi/project.json
@@ -3,15 +3,15 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "Microsoft.AspNet.Mvc": "6.0.0-beta6",
-    "Microsoft.AspNet.Server.IIS": "1.0.0-beta6",
-    "Kestrel": "1.0.0-beta6",
-    "Microsoft.AspNet.Server.WebListener": "1.0.0-beta6",
-    "Microsoft.AspNet.StaticFiles": "1.0.0-beta6"
+    "Microsoft.AspNet.Mvc": "6.0.0-beta7",
+    "Microsoft.AspNet.Server.IIS": "1.0.0-beta7",
+    "Microsoft.AspNet.Server.Kestrel": "1.0.0-beta7",
+    "Microsoft.AspNet.Server.WebListener": "1.0.0-beta7",
+    "Microsoft.AspNet.StaticFiles": "1.0.0-beta7"
   },
 
   "commands": {
-    "kestrel": "Microsoft.AspNet.Hosting --server Kestrel --config hosting.ini",
+    "kestrel": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.Kestrel --config hosting.ini",
     "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --config hosting.ini"
   },
 


### PR DESCRIPTION
This PR updates WebAPI templates for `beta7`. 
The updated project passes tests - but similar to #316 problem it does not yet restore, build (and subsequently run). So the status is for now blocked. The code itself is probably correct but its successful use depends on external service probably.
https://github.com/OmniSharp/generator-aspnet/issues/316#issuecomment-135466844

Thanks!