### PR TITLE
Specify asp.net beta version in Nancy template

### DIFF
--- a/templates/projects/nancy/project.json
+++ b/templates/projects/nancy/project.json
@@ -1,7 +1,7 @@
 {
     "dependencies": {
-        "Kestrel": "1.0.0-*",
-        "Microsoft.AspNet.Owin": "1.0.0-*",
+        "Kestrel": "1.0.0-beta7",
+        "Microsoft.AspNet.Owin": "1.0.0-beta7",
         "Nancy": "1.2.0"
     },
     "commands": {


### PR DESCRIPTION
As per #328 being specific about beta version seems to be necessary with beta7 on windows.