### PR TITLE
Update Kestrel package in Nancy template for beta7

### DIFF
--- a/templates/projects/nancy/project.json
+++ b/templates/projects/nancy/project.json
@@ -1,11 +1,11 @@
 {
     "dependencies": {
-        "Kestrel": "1.0.0-beta7",
+        "Microsoft.AspNet.Server.Kestrel": "1.0.0-beta7",
         "Microsoft.AspNet.Owin": "1.0.0-beta7",
         "Nancy": "1.2.0"
     },
     "commands": {
-        "kestrel": "Microsoft.AspNet.Hosting --server Kestrel --server.urls http://localhost:5001"
+        "kestrel": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.Kestrel --server.urls http://localhost:5001"
     },
     "frameworks": {
         "dnx451": {}


### PR DESCRIPTION
The Kestrel has been renamed during beta7
The updated Nancy template project should use updated package name:
https://github.com/OmniSharp/generator-aspnet/issues/304
hence this PR.

Thanks!