### PR TITLE
Update UnitTest template project. Closes #327

### DIFF
--- a/templates/projects/unittest/project.json
+++ b/templates/projects/unittest/project.json
@@ -7,8 +7,8 @@
   "licenseUrl": "",
 
   "dependencies": {
-    "xunit": "2.1.0-beta3-build3029",
-    "xunit.runner.dnx": "2.1.0-beta3-build99"
+    "xunit": "2.1.0-rc1-build3168",
+    "xunit.runner.dnx": "2.1.0-beta5-build169"
   },
   "commands": {
     "test": "xunit.runner.dnx"
@@ -18,10 +18,10 @@
     "dnx451": { },
     "dnxcore50" : {
       "dependencies": {
-        "System.Collections": "4.0.10-beta-22816",
-        "System.Linq": "4.0.0-beta-22816",
-        "System.Threading": "4.0.10-beta-22816",
-        "Microsoft.CSharp": "4.0.0-beta-22816"
+        "System.Collections": "4.0.11-beta-23225",
+        "System.Linq": "4.0.1-beta-23225",
+        "System.Threading": "4.0.11-beta-23225",
+        "Microsoft.CSharp": "4.0.1-beta-23225"
       }
     }
   }


### PR DESCRIPTION
This PR consists of following updates:
- update xUnit according to project release notes
http://git.io/vZCIU
- update other packages from latest beta7 nuget.org feed

The xUnit version are based on xUnit release documentation pages and their latest release notes for `beta7`:
http://xunit.github.io/docs/getting-started-dnx.html

The other dependencies are updated according to latest versions available in the beta7 feed on nuget.org.

All things restores, builds and runs correctly.

```
➜  UnitTest  dnx test
xUnit.net DNX Runner (64-bit DNX 4.5.1)
  Discovering: UnitTest
  Discovered:  UnitTest
  Starting:    UnitTest
  Finished:    UnitTest
=== TEST EXECUTION SUMMARY ===
   UnitTest  Total: 1, Errors: 0, Failed: 0, Skipped: 0, Time: 0.116s
```

The only problem I can find, is that I can't quit console and the test runner does not quit itself. The CTRL+C does not help. This could be my machine specific problem (using mono-4.0.2/Microsoft .NET Development Utility Mono-x64-1.0.0-beta7-15532)

https://github.com/xunit/xunit/issues?utf8=%E2%9C%93&q=hang

// cc 
@sayedihashimi 