### PR TITLE
:memo: Add xUnit usage tip. Closes #342

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -253,6 +253,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
     this.log(chalk.green('    dnu build') + ' (optional, build will also happen when it\'s run)');
     this.log(chalk.green('    dnx ConsoleApplication') + ' for console projects');
     this.log(chalk.green('    dnx kestrel') + ' or ' + chalk.green('dnx web') + ' for web projects');
+    this.log(chalk.green('    dnx test') + ' for unit test projects');
     this.log('\r\n');
 
   }


### PR DESCRIPTION
The xUnit project is missing usage tip
that are shown to users when generator
ends. This commit add short usage tip
to fix this.

Discussed:
https://github.com/OmniSharp/generator-aspnet/issues/342

The usage tip based on documented command:
http://xunit.github.io/docs/getting-started-dnx.html

```
Your project is now created, you can use the following commands to get going
    cd "UnitTest"
    dnu restore
    dnu build (optional, build will also happen when it's run)
    dnx ConsoleApplication for console projects
    dnx kestrel or dnx web for web projects
    dnx test for unit test projects
```

Thanks!