### PR TITLE
Swap slash in path literal to forwad slash. Closes #345

### DIFF
--- a/templates/projects/web/Startup.cs
+++ b/templates/projects/web/Startup.cs
@@ -38,7 +38,7 @@ namespace <%= namespace %>
             }
             builder.AddEnvironmentVariables();
             Configuration = builder.Build();
-            Configuration["Data:DefaultConnection:ConnectionString"] = $@"Data Source={appEnv.ApplicationBasePath}\<%= namespace %>.db";
+            Configuration["Data:DefaultConnection:ConnectionString"] = $@"Data Source={appEnv.ApplicationBasePath}/<%= namespace %>.db";
         }
 
         public IConfigurationRoot Configuration { get; set; }


### PR DESCRIPTION
This small PR changes slash in path literal used in Web application template to use forward slashes as hinted by ASP.NET 5 team member:
https://github.com/OmniSharp/generator-aspnet/issues/345#issue-105902213

The change is tested on Mac OS X 10.10.* machine with beta7 installed and SQLite 3.8.5. Here is what application creates when user account is created:
```
➜  WebApplication  sqlite3 WebApplication.db
SQLite version 3.8.5 2014-08-15 22:37:57
Enter ".help" for usage hints.
sqlite> .tables
AspNetRoleClaims    AspNetUserClaims    AspNetUserRoles     __MigrationHistory
AspNetRoles         AspNetUserLogins    AspNetUsers       
sqlite> SELECT * FROM AspNetUsers;
3df95d75-3826-4730-adc7-08f7f6595194|0|828e2891-46e1-456f-ab5e-7e126dbd05b6|BLAZEJEWICZ@########|0|1||BLAZEJEWICZ@########|BLAZEJEWICZ@########||AQAAAAEAACcQAAAAEEsAI5KtdGUNyEPr1DgFQcijBJSbWBg6KlbeszRBbJx9Ws2a4E2KTs7vc6SShx5ljw==||0|eaf5704d-b163-4571-808d-c6b4d6748d9f|0|BLAZEJEWICZ@########
sqlite>
```

Thanks!