### PR TITLE
Unify scaffolding code of wwwroot directory

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -126,7 +126,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.copy(this.sourceRoot() + '/project.json', this.applicationName + '/project.json');
 
         /// wwwroot
-        this.fs.copy(this.templatePath('/wwwroot'), this.destinationPath(this.applicationName + '/wwwroot'));
+        this.fs.copy(this.templatePath('wwwroot/**/*'), this.applicationName + '/wwwroot');
         break;
 
       case 'webapi':


### PR DESCRIPTION
I've tested updated dependencies in `project.json` and this PR is the results of such test. After this change all code that copy content into `wwwroot` will use the same implementation in all cases.

The change is future proof for yeoman-generator 0.20
under which changed code was failing to create content
and tests will filing. This little change unifies
implementation of code routines that create and copy
content into `wwwroot` directory

Thanks!