### PR TITLE
Use port 5000 in Nancy template. Closes #361

### DIFF
--- a/templates/projects/nancy/project.json
+++ b/templates/projects/nancy/project.json
@@ -5,7 +5,7 @@
         "Nancy": "1.2.0"
     },
     "commands": {
-        "kestrel": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.Kestrel --server.urls http://localhost:5001"
+        "kestrel": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.Kestrel --server.urls http://localhost:5000"
     },
     "frameworks": {
         "dnx451": {}


### PR DESCRIPTION
This commit changes the port used by server in Nancy
template project. After this change all templates
will use the same 5000 port for web applications -
unifying user experience when launching examples

Thanks!