### PR TITLE
Remove unnecessary command from ConsoleApplication template

### DIFF
--- a/templates/projects/console/project.json
+++ b/templates/projects/console/project.json
@@ -9,7 +9,6 @@
   "dependencies": {},
 
   "commands": {
-    "ConsoleApplication": "ConsoleApplication"
   },
 
   "frameworks": {


### PR DESCRIPTION
The `ConsoleApplication` command just crashed anyway. Having it in the `project.json` was confusing.