### PR TITLE
:art: Refactor subgenerators output messages

### DIFF
--- a/script-base-basic.js
+++ b/script-base-basic.js
@@ -2,6 +2,7 @@
 var util = require('util');
 var path = require('path');
 var yeoman = require('yeoman-generator');
+var chalk = require('chalk');
 
 var Generator = module.exports = function Generator() {
   yeoman.generators.Base.apply(this, arguments);
@@ -11,7 +12,7 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, yeoman.generators.Base);
 
 Generator.prototype.generateStandardFile = function(sourceFile, targetFile) {
-  this.log('You called the aspnet subgenerator with the arg ' + sourceFile);
+  this.log('You called the aspnet subgenerator with the arg: ' + chalk.green(this.arguments[0] || targetFile));
   this.fs.copy(this.templatePath(sourceFile), this.destinationPath(targetFile));
-  this.log(targetFile + ' created.');
+  this.log(chalk.green(targetFile) + ' created.');
 };

--- a/script-base.js
+++ b/script-base.js
@@ -2,6 +2,7 @@
 var util = require('util');
 var path = require('path');
 var yeoman = require('yeoman-generator');
+var chalk = require('chalk');
 
 var NamedGenerator = module.exports = function NamedGenerator() {
   yeoman.generators.NamedBase.apply(this, arguments);
@@ -11,11 +12,11 @@ var NamedGenerator = module.exports = function NamedGenerator() {
 util.inherits(NamedGenerator, yeoman.generators.NamedBase);
 
 NamedGenerator.prototype.generateTemplateFile = function(templateFile, targetFile, templateData) {
-  this.log('You called the aspnet subgenerator with the arg ' + this.name);
+  this.log('You called the aspnet subgenerator with the arg ' + chalk.green(this.arguments[0] || targetFile));
   if (templateData !== null) {
     this.fs.copyTpl(this.templatePath(templateFile), this.destinationPath(targetFile), templateData);
   } else {
     this.fs.copyTpl(this.templatePath(templateFile), this.destinationPath(targetFile));
   }
-  this.log(targetFile + ' created.');
+  this.log(chalk.green(targetFile) + ' created.');
 };


### PR DESCRIPTION
I've came into this output message when adding a Dockerfile:
```
yo aspnet:Dockerfile
You called the aspnet subgenerator with the arg Dockerfile.txt
Dockerfile created.
   create Dockerfile
```
```
You called the aspnet subgenerator with the arg Dockerfile.txt
```
No, I didn't use `Dockerfile.txt`. The generator outputs this based on template filename, which sometimes can be completely different.

This PR unifies the output to at least not display template filenames wherever possible. The output filename (with extension if exists) will be always shown to use or exactly the filename entered by user (as argument to subgenerator):

Hence:
before:
```
yo aspnet:Dockerfile
You called the aspnet subgenerator with the arg Dockerfile.txt
Dockerfile created.
   create Dockerfile
```
after:
```
yo aspnet:Dockerfile
You called the aspnet subgenerator with the arg: Dockerfile
Dockerfile created.
  create Dockerfile
```
before:
```
yo aspnet:MvcController Home
You called the aspnet subgenerator with the arg Home
Home.cs created.
```
after:
```
yo aspnet:MvcController Home
You called the aspnet subgenerator with the arg Home
Home.cs created.
   create Home.cs
```
before:
```
yo aspnet:gitignore
You called the aspnet subgenerator with the arg gitignore.txt
.gitignore created.
  create .gitignore
```
after:
```
yo aspnet:gitignore
You called the aspnet subgenerator with the arg .gitignore
.gitignore created.
  create .gitignore
```

I've added colorized strings to outline important parts of messages on supported environments:

![20150927170619](https://cloud.githubusercontent.com/assets/14539/10123497/21afd20c-653b-11e5-8d1b-6c0828c8faec.jpg)

Thanks!