### PR TITLE
Added missing semi-colon to Mocha describe statement for Dockerfile s…

### DIFF
--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -52,7 +52,7 @@ describe('Subgenerators without arguments tests', function() {
   describe('aspnet:Dockerfile', function () {
     util.goCreate('Dockerfile');
     util.fileCheck('should create Dockerfile', 'Dockerfile');
-  })
+  });
 
 });
 


### PR DESCRIPTION
I added a semi-colon to terminate the Mocha describe statement for the Dockerfile subgenerator. This change was made in test/subgenerators.js.