### PR TITLE
Add missing web.config to web basic template

### DIFF
--- a/templates/projects/webbasic/wwwroot/web.config
+++ b/templates/projects/webbasic/wwwroot/web.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <handlers>
+      <add name="httpPlatformHandler" path="*" verb="*" modules="httpPlatformHandler" resourceType="Unspecified"/>
+    </handlers>
+    <httpPlatform processPath="%DNX_PATH%" arguments="%DNX_ARGS%" stdoutLogEnabled="false"/>
+  </system.webServer>
+</configuration>

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -446,7 +446,8 @@ describe('aspnet - Web Application Basic', function() {
     'webTest/wwwroot/images/ASP-NET-Banners-02.png',
     'webTest/wwwroot/images/Banner-01-Azure.png',
     'webTest/wwwroot/images/Banner-02-VS.png',
-    'webTest/wwwroot/js/site.js'
+    'webTest/wwwroot/js/site.js',
+    'webTest/wwwroot/web.config'
   ];
   describe('Checking files', function() {
     for (var i = 0; i < files.length; i++) {


### PR DESCRIPTION
This adds `web.config` to web basic template for beta8.
Note: the web.config is problaby required when hosting
your project on IIS container

/cc 
@sayedihashimi 