### PR TITLE
:memo: Add usage help for gitignore subgenerator

### DIFF
--- a/gitignore/USAGE
+++ b/gitignore/USAGE
@@ -1,0 +1,8 @@
+Description:
+	Creates a new .gitignore file
+
+Example:
+	yo aspnet:gitignore
+
+	This will create:
+		.gitignore


### PR DESCRIPTION
Somehow the usage help file is missing for .gitignore subgenerator.
This commit adds that file with content based on other usage
files content.

Thanks!