### PR TITLE
Fix error message when trying to run generated console app

### DIFF
--- a/templates/projects/console/project.json
+++ b/templates/projects/console/project.json
@@ -13,7 +13,7 @@
   },
 
   "commands": {
-    "ConsoleApplication": "ConsoleApplication"
+    "ConsoleApplication": "run"
   },
 
   "frameworks": {


### PR DESCRIPTION
After generating the console app and attempting to execute it, the user receives the following error:

    Error: Unable to load application or execute command 'ConsoleApplication'. Available commands: ConsoleApplication.

Changing the command to "run" addresses this and the console app runs correctly.

I've only started experimenting with DNX - let me know if there is a better way and I'd be happy to modify.