### PR TITLE
:arrow_up: Bump Gulp to 3.9.0. Closes #337

### DIFF
--- a/templates/projects/web/package.json
+++ b/templates/projects/web/package.json
@@ -2,7 +2,7 @@
   "name": "<%= namespace %>",
   "version": "0.0.0",
   "devDependencies": {<% if(!grunt){ %>
-    "gulp": "3.8.11",
+    "gulp": "^3.9.0",
     "gulp-concat": "2.5.2",
     "gulp-cssmin": "0.1.7",
     "gulp-uglify": "1.2.0",

--- a/templates/projects/webbasic/package.json
+++ b/templates/projects/webbasic/package.json
@@ -2,7 +2,7 @@
   "name": "<%= namespace %>",
   "version": "0.0.0",
   "devDependencies": {<% if(!grunt){ %>
-    "gulp": "3.8.11",
+    "gulp": "^3.9.0",
     "gulp-concat": "2.5.2",
     "gulp-cssmin": "0.1.7",
     "gulp-uglify": "1.2.0",


### PR DESCRIPTION
This commit changes the Gulp version to default one installed
at the time of commit via NPM. This removes warnings that users
could see when running Gulp tasks shipped with templates about
versions mismatch

Before:
```
$  gulp --version
[19:26:08] CLI version 3.9.0
[19:26:08] Local version 3.8.11
```
After:
```
$ gulp --version
[19:20:53] CLI version 3.9.0
[19:20:53] Local version 3.9.0
```