### PR TITLE
Fix to aspnet/Templates #245

### DIFF
--- a/templates/projects/console/project.json
+++ b/templates/projects/console/project.json
@@ -13,7 +13,7 @@
   },
 
   "commands": {
-    "ConsoleApplication": "ConsoleApplication"
+    "<%= namespace %>": "<%= namespace %>"
   },
 
   "frameworks": {


### PR DESCRIPTION
Fixed https://github.com/aspnet/Templates/issues/245
/cc @peterblazejewicz 
Should pass the namespace which contains a Main method. It cannot be run when pass a wrong namespace.