### PR TITLE
Standardize Gulp and Grunt files

### DIFF
--- a/templates/Gruntfile.js
+++ b/templates/Gruntfile.js
@@ -2,7 +2,8 @@
   This file in the main entry point for defining grunt tasks and using grunt plugins.
   Click here to learn more. http://go.microsoft.com/fwlink/?LinkID=513275&clcid=0x409
 */
-'use strict';
+"use strict";
+
 module.exports = function(grunt) {
   grunt.initConfig({
   });

--- a/templates/gulpfile.js
+++ b/templates/gulpfile.js
@@ -2,10 +2,10 @@
   This file in the main entry point for defining Gulp tasks and using Gulp plugins.
   Click here to learn more. http://go.microsoft.com/fwlink/?LinkId=518007
 */
-'use strict';
+"use strict";
 
-var gulp = require('gulp');
+var gulp = require("gulp");
 
-gulp.task('default', function() {
+gulp.task("default", function() {
   // place code for your default task here
 });

--- a/templates/projects/web/Gruntfile.js
+++ b/templates/projects/web/Gruntfile.js
@@ -1,7 +1,8 @@
 // This file in the main entry point for defining grunt tasks and using grunt plugins.
 // Click here to learn more. http://go.microsoft.com/fwlink/?LinkID=513275&clcid=0x409
+"use strict";
+
 module.exports = function(grunt) {
-  'use strict';
   grunt.initConfig({
     bower: {
       install: {

--- a/templates/projects/web/gulpfile.js
+++ b/templates/projects/web/gulpfile.js
@@ -1,5 +1,6 @@
 /// <binding Clean='clean' />
-'use strict';
+"use strict";
+
 var gulp = require("gulp"),
   rimraf = require("rimraf"),
   concat = require("gulp-concat"),

--- a/templates/projects/webbasic/Gruntfile.js
+++ b/templates/projects/webbasic/Gruntfile.js
@@ -1,7 +1,8 @@
 // This file in the main entry point for defining grunt tasks and using grunt plugins.
 // Click here to learn more. http://go.microsoft.com/fwlink/?LinkID=513275&clcid=0x409
+"use strict";
+
 module.exports = function(grunt) {
-  'use strict';
   grunt.initConfig({
     bower: {
       install: {

--- a/templates/projects/webbasic/gulpfile.js
+++ b/templates/projects/webbasic/gulpfile.js
@@ -1,5 +1,6 @@
 /// <binding Clean='clean' />
-'use strict';
+"use strict";
+
 var gulp = require("gulp"),
   rimraf = require("rimraf"),
   concat = require("gulp-concat"),

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -25,7 +25,7 @@ describe('Subgenerators without arguments tests', function() {
   describe('aspnet:Gulpfile', function() {
     util.goCreate('Gulpfile');
     util.fileCheck('should create gulp file', 'gulpfile.js');
-    util.fileContentCheck('gulpfile.js', 'file content check', /gulp\.task\('default'/);
+    util.fileContentCheck('gulpfile.js', 'file content check', /gulp\.task\("default"/);
   });
 
   describe('aspnet:Gruntfile', function() {


### PR DESCRIPTION
Standardized the quotes and JS strict mode usage throughout all of the Gruntfile.js and gulpfile.js files. Addresses concerns raised in [this PR](https://github.com/OmniSharp/generator-aspnet/pull/437).