### PR TITLE
:bug: Fix TagHelper target element attribute

### DIFF
--- a/templates/TagHelper.cs
+++ b/templates/TagHelper.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNet.Razor.Runtime.TagHelpers;
 namespace <%= namespace %>
 {
     // You may need to install the Microsoft.AspNet.Razor.Runtime package into your project
-    [TargetElement("tag-name")]
+    [HtmlTargetElement("tag-name")]
     public class <%= classname %> : TagHelper
     {
         public override void Process(TagHelperContext context, TagHelperOutput output)


### PR DESCRIPTION
During `beta8` TagHelper TargetElement attribute was renamed
to HtmlTargetElement:
http://git.io/vWaaK
This commit adds that change to TagHelper scaffolding item.

Thanks!