### PR TITLE
Make Console app runnable with beta8

### DIFF
--- a/templates/projects/console/project.json
+++ b/templates/projects/console/project.json
@@ -13,7 +13,7 @@
   },
 
   "commands": {
-    "ConsoleApplication": "ConsoleApplication"
+    "ConsoleApplication": "run"
   },
 
   "frameworks": {


### PR DESCRIPTION
Not sure why but for some reason I cannot make console app running without specifying command to run as "run" as per this post on stackoverflow:
http://stackoverflow.com/questions/30267784/cannot-run-dnx-console-applications