### PR TITLE
nuget.config => NuGet.config, nuget.exe missed the current nuget.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ Produces `/ContactView.cshtml`
 
 ### nuget
 
-Creates a new `nuget.config` file
+Creates a new `NuGet.config` file
 
 Example:
 
@@ -475,7 +475,7 @@ Example:
 yo aspnet:nuget
 ```
 
-Produces `nuget.config`
+Produces `NuGet.config`
 
 [Return to top](#top)
 

--- a/nuget/index.js
+++ b/nuget/index.js
@@ -9,5 +9,5 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createItem = function() {
-  this.generateStandardFile('_nuget.config', 'nuget.config');
+  this.generateStandardFile('_nuget.config', 'NuGet.config');
 };

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -92,14 +92,14 @@ describe('Subgenerators without arguments tests', function() {
 
   describe('aspnet:nuget', function() {
     util.goCreate('nuget');
-    var filename = 'nuget.config';
+    var filename = 'NuGet.config';
     util.fileCheck('should create NuGet configuration file', filename);
     util.fileContentCheck(filename, 'Check file content', /api\.nuget\.org/);
   });
 
   describe('aspnet:nuget', function() {
     util.goCreate('nuget');
-    var filename = 'nuget.config';
+    var filename = 'NuGet.config';
     util.fileCheck('should create NuGet configuration file', filename);
     util.fileContentCheck(filename, 'Check file content', /api\.nuget\.org/);
   });


### PR DESCRIPTION
nuget.exe detect the `NuGet.config` not `nuget.config`
When you used linux, it will detect the lowercase and uppercase.
nuget.config will be missed by nuget.exe