### PR TITLE
Use FQNM to run web applications. Fixes #488

### DIFF
--- a/templates/projects/empty/Startup.cs
+++ b/templates/projects/empty/Startup.cs
@@ -29,6 +29,6 @@ namespace <%= namespace %>
         }
 
         // Entry point for the application.
-        public static void Main(string[] args) => WebApplication.Run<Startup>(args);
+        public static void Main(string[] args) => Microsoft.AspNet.Hosting.WebApplication.Run<Startup>(args);
     }
 }

--- a/templates/projects/web/Startup.cs
+++ b/templates/projects/web/Startup.cs
@@ -99,6 +99,6 @@ namespace <%= namespace %>
         }
 
         // Entry point for the application.
-        public static void Main(string[] args) => WebApplication.Run<Startup>(args);
+        public static void Main(string[] args) => Microsoft.AspNet.Hosting.WebApplication.Run<Startup>(args);
     }
 }

--- a/templates/projects/webapi/Startup.cs
+++ b/templates/projects/webapi/Startup.cs
@@ -44,6 +44,6 @@ namespace <%= namespace %>
         }
 
         // Entry point for the application.
-        public static void Main(string[] args) => WebApplication.Run<Startup>(args);
+        public static void Main(string[] args) => Microsoft.AspNet.Hosting.WebApplication.Run<Startup>(args);
     }
 }

--- a/templates/projects/webbasic/Startup.cs
+++ b/templates/projects/webbasic/Startup.cs
@@ -60,6 +60,6 @@ namespace <%= namespace %>
         }
 
         // Entry point for the application.
-        public static void Main(string[] args) => WebApplication.Run<Startup>(args);
+        public static void Main(string[] args) => Microsoft.AspNet.Hosting.WebApplication.Run<Startup>(args);
     }
 }


### PR DESCRIPTION
There is a chance of name collisions as default project type
for web application is named in Visual Studio and in generator
in the same way as class responsible for hosting/running web
application in Microsoft.AspNet.Hosting: WebApplication
This commits make sure that at least for rc1 we do not put users
into build error due to compiler confusion.
All related web projects uses full-qualified class name
as work-around until naming convention is agreed


All project have been tested with this change for `restore`, `build` and `dnx web` commands and run locally.

Thanks!