### PR TITLE
:bug: Remove RC2 Razor feature from RC1

### DIFF
--- a/templates/projects/web/Views/_ViewImports.cshtml
+++ b/templates/projects/web/Views/_ViewImports.cshtml
@@ -3,4 +3,4 @@
 @using <%= namespace %>.ViewModels.Account
 @using <%= namespace %>.ViewModels.Manage
 @using Microsoft.AspNet.Identity
-@addTagHelper *, Microsoft.AspNet.Mvc.TagHelpers
+@addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"


### PR DESCRIPTION
The quotes are still required under RC1 in Razor imports.
See: http://git.io/v42hL
The feature slipped in into RC1 by mistake - hence fix.

Thanks!