### PR TITLE
Update xUnit template project for RC1. Closes #497

### DIFF
--- a/templates/projects/unittest/SampleTest.cs
+++ b/templates/projects/unittest/SampleTest.cs
@@ -5,12 +5,25 @@ using Xunit;
 
 namespace <%= namespace %>
 {
+    // see example explanation on xUnit.net website:
+    // https://xunit.github.io/docs/getting-started-dnx.html
     public class SampleTest
     {
         [Fact]
-        public void Test1()
+        public void PassingTest()
         {
-        	Assert.True(true);
+            Assert.Equal(4, Add(2, 2));
+        }
+
+        [Fact]
+        public void FailingTest()
+        {
+            Assert.Equal(5, Add(2, 2));
+        }
+
+        int Add(int x, int y)
+        {
+            return x + y;
         }
     }
 }

--- a/templates/projects/unittest/project.json
+++ b/templates/projects/unittest/project.json
@@ -1,31 +1,22 @@
 {
-  "version": "1.0.0-*",
-  "description": "",
-  "authors": [ "" ],
-  "tags": [ "" ],
-  "projectUrl": "",
-  "licenseUrl": "",
-  "tooling": {
-    "defaultNamespace": "<%= namespace %>"
-  },
-
-  "dependencies": {
-    "xunit": "2.1.0",
-    "xunit.runner.dnx": "2.1.0-beta6-build191"
-  },
-  "commands": {
-    "test": "xunit.runner.dnx"
-  },
-
-  "frameworks" : {
-    "dnx451": { },
-    "dnxcore50" : {
-      "dependencies": {
-        "System.Collections": "4.0.11-beta-23225",
-        "System.Linq": "4.0.1-beta-23225",
-        "System.Threading": "4.0.11-beta-23225",
-        "Microsoft.CSharp": "4.0.1-beta-23225"
-      }
+    "version": "1.0.0-*",
+    "description": "",
+    "authors": [ "" ],
+    "tags": [ "" ],
+    "projectUrl": "",
+    "licenseUrl": "",
+    "tooling": {
+      "defaultNamespace": "<%= namespace %>"
+    },
+    "dependencies": {
+        "xunit": "2.1.0",
+        "xunit.runner.dnx": "2.1.0-rc1-build204"
+    },
+    "commands": {
+        "test": "xunit.runner.dnx"
+    },
+    "frameworks": {
+        "dnx451": { },
+        "dnxcore50": { }
     }
-  }
 }


### PR DESCRIPTION
- add project.json fully based on xUnit example:
- use implementation example based on xUnit example code:
https://xunit.github.io/docs/getting-started-dnx.html

The `project.json` is rewritten - but it incorporate our tooling addition.

This commit is based on xUnit RC1 release notes and updates:
https://xunit.github.io/release-notes/2015-11-18.html

The results were tested on mono RC1 run on OS X with `dnu restore`, `dnu build` and `dnx test`:

The results are the same as explained in xUnit.net documentation template when running example test:

```
➜  UnitTest  dnx test
xUnit.net DNX Runner (64-bit DNX 4.5.1)
  Discovering: UnitTest
  Discovered:  UnitTest
  Starting:    UnitTest
    UnitTest.SampleTest.FailingTest [FAIL]
      Assert.Equal() Failure
      Expected: 5
      Actual:   4
      Stack Trace:
          at UnitTest.SampleTest.FailingTest () [0x00000] in <filename unknown>:0 
          at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
          at System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00000] in <filename unknown>:0 
  Finished:    UnitTest
=== TEST EXECUTION SUMMARY ===
   UnitTest  Total: 2, Errors: 0, Failed: 1, Skipped: 0, Time: 0.121s
```

https://xunit.github.io/docs/getting-started-dnx.html

@bradwilson Mind reviewing?

Thanks!

/cc @sayedihashimi 