### PR TITLE
:memo: Update content of projects' readme files

### DIFF
--- a/templates/projects/empty/wwwroot/README.md
+++ b/templates/projects/empty/wwwroot/README.md
@@ -1,42 +1,36 @@
-# Welcome to ASP.NET 5 Preview
-
+# Welcome to ASP.NET 5
 We've made some big updates in this release, so it’s **important** that you spend a few minutes to learn what’s new.
 
-ASP.NET 5 has been rearchitected to make it **lean** and **composable**. It's fully **open source** and available on [GitHub](http://go.microsoft.com/fwlink/?LinkID=517854).
-Your new project automatically takes advantage of modern client-side utilities like [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) and [npm](http://go.microsoft.com/fwlink/?LinkId=518005) (to add client-side libraries) and [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) (for client-side build and automation tasks).
+**You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)**
 
-We hope you enjoy the new capabilities in ASP.NET 5 and Visual Studio 2015.
-The ASP.NET Team
-
-### You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
-
-### This application consists of:
+## This application consists of:
 * Sample pages using ASP.NET MVC 6
 * [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side resources
 * Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
 
-#### NEW CONCEPTS
-* [The 'wwwroot' explained](http://go.microsoft.com/fwlink/?LinkId=518008)
-* [Configuration in ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518012)
-* [Dependency Injection](http://go.microsoft.com/fwlink/?LinkId=518013)
-* [Razor TagHelpers](http://go.microsoft.com/fwlink/?LinkId=518014)
-* [Manage client packages using Gulp](http://go.microsoft.com/fwlink/?LinkID=517849)
-* [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=517850)
+## How to
+* [Add a Controller and View](http://go.microsoft.com/fwlink/?LinkID=398600)
+* [Add an appsetting in config and access it in app.](http://go.microsoft.com/fwlink/?LinkID=699562)
+* [Manage User Secrets using Secret Manager.](http://go.microsoft.com/fwlink/?LinkId=699315)
+* [Use logging to log a message.](http://go.microsoft.com/fwlink/?LinkId=699316)
+* [Add packages using NuGet.](http://go.microsoft.com/fwlink/?LinkId=699317)
+* [Add client packages using Bower.](http://go.microsoft.com/fwlink/?LinkId=699318)
+* [Target development, staging or production environment.](http://go.microsoft.com/fwlink/?LinkId=699319)
 
-#### CUSTOMIZE APP
-* [Add Controllers and Views](http://go.microsoft.com/fwlink/?LinkID=398600)
-* [Add Data using EntityFramework](http://go.microsoft.com/fwlink/?LinkID=398602)
-* [Add Authentication using Identity](http://go.microsoft.com/fwlink/?LinkID=398603)
-* [Add real time support using SignalR](http://go.microsoft.com/fwlink/?LinkID=398606)
-* [Add Class library](http://go.microsoft.com/fwlink/?LinkID=398604)
-* [Add Web APIs with MVC 6](http://go.microsoft.com/fwlink/?LinkId=518009)
-* [Add client packages using Bower](http://go.microsoft.com/fwlink/?LinkID=517848)
+## Overview
+* [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
+* [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
+* [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
+* [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
+* [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)
+* [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=699322)
+* [Read more on the documentation site](http://go.microsoft.com/fwlink/?LinkID=699323)
 
-#### DEPLOY
-* [Run your app locally](http://go.microsoft.com/fwlink/?LinkID=517851)
-* [Run your app on ASP.NET Core 5](http://go.microsoft.com/fwlink/?LinkID=517852)
-* [Run commands in your 'project.json'](http://go.microsoft.com/fwlink/?LinkID=517853)
-* [Publish to Microsoft Azure Web Sites](http://go.microsoft.com/fwlink/?LinkID=398609)
-* [Publish to the file system](http://go.microsoft.com/fwlink/?LinkId=518019)
+## Run & Deploy
+* [Run your app](http://go.microsoft.com/fwlink/?LinkID=517851)
+* [Run your app on .NET Core](http://go.microsoft.com/fwlink/?LinkID=517852)
+* [Run commands in your project.json](http://go.microsoft.com/fwlink/?LinkID=517853)
+* [Publish to Microsoft Azure Web Apps](http://go.microsoft.com/fwlink/?LinkID=398609)
+
 
 We would love to hear your [feedback](http://go.microsoft.com/fwlink/?LinkId=518015)

--- a/templates/projects/web/README.md
+++ b/templates/projects/web/README.md
@@ -1,42 +1,36 @@
-# Welcome to ASP.NET 5 Preview
-
+# Welcome to ASP.NET 5
 We've made some big updates in this release, so it’s **important** that you spend a few minutes to learn what’s new.
 
-ASP.NET 5 has been rearchitected to make it **lean** and **composable**. It's fully **open source** and available on [GitHub](http://go.microsoft.com/fwlink/?LinkID=517854).
-Your new project automatically takes advantage of modern client-side utilities like [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) and [npm](http://go.microsoft.com/fwlink/?LinkId=518005) (to add client-side libraries) and [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) (for client-side build and automation tasks).
+**You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)**
 
-We hope you enjoy the new capabilities in ASP.NET 5 and Visual Studio 2015.
-The ASP.NET Team
-
-### You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
-
-### This application consists of:
+## This application consists of:
 * Sample pages using ASP.NET MVC 6
 * [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side resources
 * Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
 
-#### NEW CONCEPTS
-* [The 'wwwroot' explained](http://go.microsoft.com/fwlink/?LinkId=518008)
-* [Configuration in ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518012)
-* [Dependency Injection](http://go.microsoft.com/fwlink/?LinkId=518013)
-* [Razor TagHelpers](http://go.microsoft.com/fwlink/?LinkId=518014)
-* [Manage client packages using Gulp](http://go.microsoft.com/fwlink/?LinkID=517849)
-* [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=517850)
+## How to
+* [Add a Controller and View](http://go.microsoft.com/fwlink/?LinkID=398600)
+* [Add an appsetting in config and access it in app.](http://go.microsoft.com/fwlink/?LinkID=699562)
+* [Manage User Secrets using Secret Manager.](http://go.microsoft.com/fwlink/?LinkId=699315)
+* [Use logging to log a message.](http://go.microsoft.com/fwlink/?LinkId=699316)
+* [Add packages using NuGet.](http://go.microsoft.com/fwlink/?LinkId=699317)
+* [Add client packages using Bower.](http://go.microsoft.com/fwlink/?LinkId=699318)
+* [Target development, staging or production environment.](http://go.microsoft.com/fwlink/?LinkId=699319)
 
-#### CUSTOMIZE APP
-* [Add Controllers and Views](http://go.microsoft.com/fwlink/?LinkID=398600)
-* [Add Data using EntityFramework](http://go.microsoft.com/fwlink/?LinkID=398602)
-* [Add Authentication using Identity](http://go.microsoft.com/fwlink/?LinkID=398603)
-* [Add real time support using SignalR](http://go.microsoft.com/fwlink/?LinkID=398606)
-* [Add Class library](http://go.microsoft.com/fwlink/?LinkID=398604)
-* [Add Web APIs with MVC 6](http://go.microsoft.com/fwlink/?LinkId=518009)
-* [Add client packages using Bower](http://go.microsoft.com/fwlink/?LinkID=517848)
+## Overview
+* [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
+* [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
+* [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
+* [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
+* [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)
+* [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=699322)
+* [Read more on the documentation site](http://go.microsoft.com/fwlink/?LinkID=699323)
 
-#### DEPLOY
-* [Run your app locally](http://go.microsoft.com/fwlink/?LinkID=517851)
-* [Run your app on ASP.NET Core 5](http://go.microsoft.com/fwlink/?LinkID=517852)
-* [Run commands in your 'project.json'](http://go.microsoft.com/fwlink/?LinkID=517853)
-* [Publish to Microsoft Azure Web Sites](http://go.microsoft.com/fwlink/?LinkID=398609)
-* [Publish to the file system](http://go.microsoft.com/fwlink/?LinkId=518019)
+## Run & Deploy
+* [Run your app](http://go.microsoft.com/fwlink/?LinkID=517851)
+* [Run your app on .NET Core](http://go.microsoft.com/fwlink/?LinkID=517852)
+* [Run commands in your project.json](http://go.microsoft.com/fwlink/?LinkID=517853)
+* [Publish to Microsoft Azure Web Apps](http://go.microsoft.com/fwlink/?LinkID=398609)
+
 
 We would love to hear your [feedback](http://go.microsoft.com/fwlink/?LinkId=518015)

--- a/templates/projects/webapi/wwwroot/README.md
+++ b/templates/projects/webapi/wwwroot/README.md
@@ -1,42 +1,36 @@
-# Welcome to ASP.NET 5 Preview
-
+# Welcome to ASP.NET 5
 We've made some big updates in this release, so it’s **important** that you spend a few minutes to learn what’s new.
 
-ASP.NET 5 has been rearchitected to make it **lean** and **composable**. It's fully **open source** and available on [GitHub](http://go.microsoft.com/fwlink/?LinkID=517854).
-Your new project automatically takes advantage of modern client-side utilities like [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) and [npm](http://go.microsoft.com/fwlink/?LinkId=518005) (to add client-side libraries) and [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) (for client-side build and automation tasks).
+**You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)**
 
-We hope you enjoy the new capabilities in ASP.NET 5 and Visual Studio 2015.
-The ASP.NET Team
-
-### You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
-
-### This application consists of:
+## This application consists of:
 * Sample pages using ASP.NET MVC 6
 * [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side resources
 * Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
 
-#### NEW CONCEPTS
-* [The 'wwwroot' explained](http://go.microsoft.com/fwlink/?LinkId=518008)
-* [Configuration in ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518012)
-* [Dependency Injection](http://go.microsoft.com/fwlink/?LinkId=518013)
-* [Razor TagHelpers](http://go.microsoft.com/fwlink/?LinkId=518014)
-* [Manage client packages using Gulp](http://go.microsoft.com/fwlink/?LinkID=517849)
-* [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=517850)
+## How to
+* [Add a Controller and View](http://go.microsoft.com/fwlink/?LinkID=398600)
+* [Add an appsetting in config and access it in app.](http://go.microsoft.com/fwlink/?LinkID=699562)
+* [Manage User Secrets using Secret Manager.](http://go.microsoft.com/fwlink/?LinkId=699315)
+* [Use logging to log a message.](http://go.microsoft.com/fwlink/?LinkId=699316)
+* [Add packages using NuGet.](http://go.microsoft.com/fwlink/?LinkId=699317)
+* [Add client packages using Bower.](http://go.microsoft.com/fwlink/?LinkId=699318)
+* [Target development, staging or production environment.](http://go.microsoft.com/fwlink/?LinkId=699319)
 
-#### CUSTOMIZE APP
-* [Add Controllers and Views](http://go.microsoft.com/fwlink/?LinkID=398600)
-* [Add Data using EntityFramework](http://go.microsoft.com/fwlink/?LinkID=398602)
-* [Add Authentication using Identity](http://go.microsoft.com/fwlink/?LinkID=398603)
-* [Add real time support using SignalR](http://go.microsoft.com/fwlink/?LinkID=398606)
-* [Add Class library](http://go.microsoft.com/fwlink/?LinkID=398604)
-* [Add Web APIs with MVC 6](http://go.microsoft.com/fwlink/?LinkId=518009)
-* [Add client packages using Bower](http://go.microsoft.com/fwlink/?LinkID=517848)
+## Overview
+* [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
+* [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
+* [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
+* [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
+* [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)
+* [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=699322)
+* [Read more on the documentation site](http://go.microsoft.com/fwlink/?LinkID=699323)
 
-#### DEPLOY
-* [Run your app locally](http://go.microsoft.com/fwlink/?LinkID=517851)
-* [Run your app on ASP.NET Core 5](http://go.microsoft.com/fwlink/?LinkID=517852)
-* [Run commands in your 'project.json'](http://go.microsoft.com/fwlink/?LinkID=517853)
-* [Publish to Microsoft Azure Web Sites](http://go.microsoft.com/fwlink/?LinkID=398609)
-* [Publish to the file system](http://go.microsoft.com/fwlink/?LinkId=518019)
+## Run & Deploy
+* [Run your app](http://go.microsoft.com/fwlink/?LinkID=517851)
+* [Run your app on .NET Core](http://go.microsoft.com/fwlink/?LinkID=517852)
+* [Run commands in your project.json](http://go.microsoft.com/fwlink/?LinkID=517853)
+* [Publish to Microsoft Azure Web Apps](http://go.microsoft.com/fwlink/?LinkID=398609)
+
 
 We would love to hear your [feedback](http://go.microsoft.com/fwlink/?LinkId=518015)

--- a/templates/projects/webbasic/README.md
+++ b/templates/projects/webbasic/README.md
@@ -1,42 +1,36 @@
-# Welcome to ASP.NET 5 Preview
-
+# Welcome to ASP.NET 5
 We've made some big updates in this release, so it’s **important** that you spend a few minutes to learn what’s new.
 
-ASP.NET 5 has been rearchitected to make it **lean** and **composable**. It's fully **open source** and available on [GitHub](http://go.microsoft.com/fwlink/?LinkID=517854).
-Your new project automatically takes advantage of modern client-side utilities like [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) and [npm](http://go.microsoft.com/fwlink/?LinkId=518005) (to add client-side libraries) and [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) (for client-side build and automation tasks).
+**You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)**
 
-We hope you enjoy the new capabilities in ASP.NET 5 and Visual Studio 2015.
-The ASP.NET Team
-
-### You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
-
-### This application consists of:
+## This application consists of:
 * Sample pages using ASP.NET MVC 6
 * [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side resources
 * Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
 
-#### NEW CONCEPTS
-* [The 'wwwroot' explained](http://go.microsoft.com/fwlink/?LinkId=518008)
-* [Configuration in ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518012)
-* [Dependency Injection](http://go.microsoft.com/fwlink/?LinkId=518013)
-* [Razor TagHelpers](http://go.microsoft.com/fwlink/?LinkId=518014)
-* [Manage client packages using Gulp](http://go.microsoft.com/fwlink/?LinkID=517849)
-* [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=517850)
+## How to
+* [Add a Controller and View](http://go.microsoft.com/fwlink/?LinkID=398600)
+* [Add an appsetting in config and access it in app.](http://go.microsoft.com/fwlink/?LinkID=699562)
+* [Manage User Secrets using Secret Manager.](http://go.microsoft.com/fwlink/?LinkId=699315)
+* [Use logging to log a message.](http://go.microsoft.com/fwlink/?LinkId=699316)
+* [Add packages using NuGet.](http://go.microsoft.com/fwlink/?LinkId=699317)
+* [Add client packages using Bower.](http://go.microsoft.com/fwlink/?LinkId=699318)
+* [Target development, staging or production environment.](http://go.microsoft.com/fwlink/?LinkId=699319)
 
-#### CUSTOMIZE APP
-* [Add Controllers and Views](http://go.microsoft.com/fwlink/?LinkID=398600)
-* [Add Data using EntityFramework](http://go.microsoft.com/fwlink/?LinkID=398602)
-* [Add Authentication using Identity](http://go.microsoft.com/fwlink/?LinkID=398603)
-* [Add real time support using SignalR](http://go.microsoft.com/fwlink/?LinkID=398606)
-* [Add Class library](http://go.microsoft.com/fwlink/?LinkID=398604)
-* [Add Web APIs with MVC 6](http://go.microsoft.com/fwlink/?LinkId=518009)
-* [Add client packages using Bower](http://go.microsoft.com/fwlink/?LinkID=517848)
+## Overview
+* [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
+* [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
+* [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
+* [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
+* [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)
+* [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=699322)
+* [Read more on the documentation site](http://go.microsoft.com/fwlink/?LinkID=699323)
 
-#### DEPLOY
-* [Run your app locally](http://go.microsoft.com/fwlink/?LinkID=517851)
-* [Run your app on ASP.NET Core 5](http://go.microsoft.com/fwlink/?LinkID=517852)
-* [Run commands in your 'project.json'](http://go.microsoft.com/fwlink/?LinkID=517853)
-* [Publish to Microsoft Azure Web Sites](http://go.microsoft.com/fwlink/?LinkID=398609)
-* [Publish to the file system](http://go.microsoft.com/fwlink/?LinkId=518019)
+## Run & Deploy
+* [Run your app](http://go.microsoft.com/fwlink/?LinkID=517851)
+* [Run your app on .NET Core](http://go.microsoft.com/fwlink/?LinkID=517852)
+* [Run commands in your project.json](http://go.microsoft.com/fwlink/?LinkID=517853)
+* [Publish to Microsoft Azure Web Apps](http://go.microsoft.com/fwlink/?LinkID=398609)
+
 
 We would love to hear your [feedback](http://go.microsoft.com/fwlink/?LinkId=518015)


### PR DESCRIPTION
This commit brings changes from aspnet/Templates project to template projects
readme files:
- no more preview remarks
- less sections
- content updates

All project that ship with README.md are updated with this commit

The updated content can be seen here:
https://github.com/peterblazejewicz/missing-aspnet-readme/blob/master/README.md

The upstream content:
https://github.com/aspnet/Templates/blob/dev/src/BaseTemplates/StarterWeb/Project_Readme.html

Thanks!