### PR TITLE
Remove blank lines from top of Startup.cs

### DIFF
--- a/templates/projects/webbasic/Startup.cs
+++ b/templates/projects/webbasic/Startup.cs
@@ -1,5 +1,3 @@
-
-
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
The "webbasic" project's Startup.cs file had 2 blank lines at the very top. This PR cleans removes that.