### PR TITLE
Remove unnecessary Microsoft.AspNet.Hosting namespace prefix

### DIFF
--- a/templates/projects/empty/Startup.cs
+++ b/templates/projects/empty/Startup.cs
@@ -29,6 +29,6 @@ namespace <%= namespace %>
         }
 
         // Entry point for the application.
-        public static void Main(string[] args) => Microsoft.AspNet.Hosting.WebApplication.Run<Startup>(args);
+        public static void Main(string[] args) => WebApplication.Run<Startup>(args);
     }
 }

--- a/templates/projects/web/Startup.cs
+++ b/templates/projects/web/Startup.cs
@@ -103,6 +103,6 @@ namespace <%= namespace %>
         }
 
         // Entry point for the application.
-        public static void Main(string[] args) => Microsoft.AspNet.Hosting.WebApplication.Run<Startup>(args);
+        public static void Main(string[] args) => WebApplication.Run<Startup>(args);
     }
 }

--- a/templates/projects/webapi/Startup.cs
+++ b/templates/projects/webapi/Startup.cs
@@ -44,6 +44,6 @@ namespace <%= namespace %>
         }
 
         // Entry point for the application.
-        public static void Main(string[] args) => Microsoft.AspNet.Hosting.WebApplication.Run<Startup>(args);
+        public static void Main(string[] args) => WebApplication.Run<Startup>(args);
     }
 }

--- a/templates/projects/webbasic/Startup.cs
+++ b/templates/projects/webbasic/Startup.cs
@@ -60,6 +60,6 @@ namespace <%= namespace %>
         }
 
         // Entry point for the application.
-        public static void Main(string[] args) => Microsoft.AspNet.Hosting.WebApplication.Run<Startup>(args);
+        public static void Main(string[] args) => WebApplication.Run<Startup>(args);
     }
 }


### PR DESCRIPTION
In 4 of the Startup.cs files, the Microsoft.AspNet.Hosting namespace prefix was used in the `Main` method. This is unnecessary, as it's imported at the top of the file.