### PR TITLE
Remove duplicate btn-default Bootstrap classes

### DIFF
--- a/templates/projects/web/Views/Home/Index.cshtml
+++ b/templates/projects/web/Views/Home/Index.cshtml
@@ -15,7 +15,7 @@
             <div class="carousel-caption">
                 <p>
                     Learn how to build ASP.NET apps that can run anywhere.
-                    <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525028&clcid=0x409">
+                    <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525028&clcid=0x409">
                         Learn More
                     </a>
                 </p>
@@ -26,7 +26,7 @@
             <div class="carousel-caption">
                 <p>
                     There are powerful new features in Visual Studio for building modern web apps.
-                    <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525030&clcid=0x409">
+                    <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525030&clcid=0x409">
                         Learn More
                     </a>
                 </p>
@@ -37,7 +37,7 @@
             <div class="carousel-caption">
                 <p>
                     Bring in libraries from NuGet, Bower, and npm, and automate tasks using Grunt or Gulp.
-                    <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525029&clcid=0x409">
+                    <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525029&clcid=0x409">
                         Learn More
                     </a>
                 </p>
@@ -48,7 +48,7 @@
             <div class="carousel-caption">
                 <p>
                     Learn how Microsoft's Azure cloud platform allows you to build, deploy, and scale web apps.
-                    <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525027&clcid=0x409">
+                    <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525027&clcid=0x409">
                         Learn More
                     </a>
                 </p>

--- a/templates/projects/webbasic/Views/Home/Index.cshtml
+++ b/templates/projects/webbasic/Views/Home/Index.cshtml
@@ -15,7 +15,7 @@
             <div class="carousel-caption">
                 <p>
                     Learn how to build ASP.NET apps that can run anywhere.
-                    <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525028&clcid=0x409">
+                    <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525028&clcid=0x409">
                         Learn More
                     </a>
                 </p>
@@ -26,7 +26,7 @@
             <div class="carousel-caption">
                 <p>
                     There are powerful new features in Visual Studio for building modern web apps.
-                    <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525030&clcid=0x409">
+                    <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525030&clcid=0x409">
                         Learn More
                     </a>
                 </p>
@@ -37,7 +37,7 @@
             <div class="carousel-caption">
                 <p>
                     Bring in libraries from NuGet, Bower, and npm, and automate tasks using Grunt or Gulp.
-                    <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525029&clcid=0x409">
+                    <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525029&clcid=0x409">
                         Learn More
                     </a>
                 </p>
@@ -48,7 +48,7 @@
             <div class="carousel-caption">
                 <p>
                     Learn how Microsoft's Azure cloud platform allows you to build, deploy, and scale web apps.
-                    <a class="btn btn-default btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525027&clcid=0x409">
+                    <a class="btn btn-default" href="http://go.microsoft.com/fwlink/?LinkID=525027&clcid=0x409">
                         Learn More
                     </a>
                 </p>


### PR DESCRIPTION
The Bootstrap `btn-default` was duplicated several times in the Index view within the "web" and "webbasic" templates.