### PR TITLE
:memo: Update template project README files

### DIFF
--- a/templates/projects/empty/wwwroot/README.md
+++ b/templates/projects/empty/wwwroot/README.md
@@ -1,36 +1,40 @@
 # Welcome to ASP.NET 5
+
 We've made some big updates in this release, so it’s **important** that you spend a few minutes to learn what’s new.
 
-**You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)**
+You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
 
 ## This application consists of:
-* Sample pages using ASP.NET MVC 6
-* [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side resources
-* Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
+
+*   Sample pages using ASP.NET MVC 6
+*   [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side libraries
+*   Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
 
 ## How to
-* [Add a Controller and View](http://go.microsoft.com/fwlink/?LinkID=398600)
-* [Add an appsetting in config and access it in app.](http://go.microsoft.com/fwlink/?LinkID=699562)
-* [Manage User Secrets using Secret Manager.](http://go.microsoft.com/fwlink/?LinkId=699315)
-* [Use logging to log a message.](http://go.microsoft.com/fwlink/?LinkId=699316)
-* [Add packages using NuGet.](http://go.microsoft.com/fwlink/?LinkId=699317)
-* [Add client packages using Bower.](http://go.microsoft.com/fwlink/?LinkId=699318)
-* [Target development, staging or production environment.](http://go.microsoft.com/fwlink/?LinkId=699319)
+
+*   [Add a Controller and View](http://go.microsoft.com/fwlink/?LinkID=398600)
+*   [Add an appsetting in config and access it in app.](http://go.microsoft.com/fwlink/?LinkID=699562)
+*   [Manage User Secrets using Secret Manager.](http://go.microsoft.com/fwlink/?LinkId=699315)
+*   [Use logging to log a message.](http://go.microsoft.com/fwlink/?LinkId=699316)
+*   [Add packages using NuGet.](http://go.microsoft.com/fwlink/?LinkId=699317)
+*   [Add client packages using Bower.](http://go.microsoft.com/fwlink/?LinkId=699318)
+*   [Target development, staging or production environment.](http://go.microsoft.com/fwlink/?LinkId=699319)
 
 ## Overview
-* [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
-* [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
-* [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
-* [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
-* [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)
-* [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=699322)
-* [Read more on the documentation site](http://go.microsoft.com/fwlink/?LinkID=699323)
+
+*   [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
+*   [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
+*   [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
+*   [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
+*   [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)
+*   [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=699322)
+*   [Read more on the documentation site](http://go.microsoft.com/fwlink/?LinkID=699323)
 
 ## Run & Deploy
-* [Run your app](http://go.microsoft.com/fwlink/?LinkID=517851)
-* [Run your app on .NET Core](http://go.microsoft.com/fwlink/?LinkID=517852)
-* [Run commands in your project.json](http://go.microsoft.com/fwlink/?LinkID=517853)
-* [Publish to Microsoft Azure Web Apps](http://go.microsoft.com/fwlink/?LinkID=398609)
 
+*   [Run your app](http://go.microsoft.com/fwlink/?LinkID=517851)
+*   [Run your app on .NET Core](http://go.microsoft.com/fwlink/?LinkID=517852)
+*   [Run commands in your project.json](http://go.microsoft.com/fwlink/?LinkID=517853)
+*   [Publish to Microsoft Azure Web Apps](http://go.microsoft.com/fwlink/?LinkID=398609)
 
 We would love to hear your [feedback](http://go.microsoft.com/fwlink/?LinkId=518015)

--- a/templates/projects/web/README.md
+++ b/templates/projects/web/README.md
@@ -1,36 +1,40 @@
 # Welcome to ASP.NET 5
+
 We've made some big updates in this release, so it’s **important** that you spend a few minutes to learn what’s new.
 
-**You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)**
+You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
 
 ## This application consists of:
-* Sample pages using ASP.NET MVC 6
-* [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side resources
-* Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
+
+*   Sample pages using ASP.NET MVC 6
+*   [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side libraries
+*   Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
 
 ## How to
-* [Add a Controller and View](http://go.microsoft.com/fwlink/?LinkID=398600)
-* [Add an appsetting in config and access it in app.](http://go.microsoft.com/fwlink/?LinkID=699562)
-* [Manage User Secrets using Secret Manager.](http://go.microsoft.com/fwlink/?LinkId=699315)
-* [Use logging to log a message.](http://go.microsoft.com/fwlink/?LinkId=699316)
-* [Add packages using NuGet.](http://go.microsoft.com/fwlink/?LinkId=699317)
-* [Add client packages using Bower.](http://go.microsoft.com/fwlink/?LinkId=699318)
-* [Target development, staging or production environment.](http://go.microsoft.com/fwlink/?LinkId=699319)
+
+*   [Add a Controller and View](http://go.microsoft.com/fwlink/?LinkID=398600)
+*   [Add an appsetting in config and access it in app.](http://go.microsoft.com/fwlink/?LinkID=699562)
+*   [Manage User Secrets using Secret Manager.](http://go.microsoft.com/fwlink/?LinkId=699315)
+*   [Use logging to log a message.](http://go.microsoft.com/fwlink/?LinkId=699316)
+*   [Add packages using NuGet.](http://go.microsoft.com/fwlink/?LinkId=699317)
+*   [Add client packages using Bower.](http://go.microsoft.com/fwlink/?LinkId=699318)
+*   [Target development, staging or production environment.](http://go.microsoft.com/fwlink/?LinkId=699319)
 
 ## Overview
-* [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
-* [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
-* [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
-* [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
-* [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)
-* [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=699322)
-* [Read more on the documentation site](http://go.microsoft.com/fwlink/?LinkID=699323)
+
+*   [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
+*   [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
+*   [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
+*   [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
+*   [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)
+*   [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=699322)
+*   [Read more on the documentation site](http://go.microsoft.com/fwlink/?LinkID=699323)
 
 ## Run & Deploy
-* [Run your app](http://go.microsoft.com/fwlink/?LinkID=517851)
-* [Run your app on .NET Core](http://go.microsoft.com/fwlink/?LinkID=517852)
-* [Run commands in your project.json](http://go.microsoft.com/fwlink/?LinkID=517853)
-* [Publish to Microsoft Azure Web Apps](http://go.microsoft.com/fwlink/?LinkID=398609)
 
+*   [Run your app](http://go.microsoft.com/fwlink/?LinkID=517851)
+*   [Run your app on .NET Core](http://go.microsoft.com/fwlink/?LinkID=517852)
+*   [Run commands in your project.json](http://go.microsoft.com/fwlink/?LinkID=517853)
+*   [Publish to Microsoft Azure Web Apps](http://go.microsoft.com/fwlink/?LinkID=398609)
 
 We would love to hear your [feedback](http://go.microsoft.com/fwlink/?LinkId=518015)

--- a/templates/projects/webapi/wwwroot/README.md
+++ b/templates/projects/webapi/wwwroot/README.md
@@ -1,36 +1,40 @@
 # Welcome to ASP.NET 5
+
 We've made some big updates in this release, so it’s **important** that you spend a few minutes to learn what’s new.
 
-**You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)**
+You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
 
 ## This application consists of:
-* Sample pages using ASP.NET MVC 6
-* [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side resources
-* Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
+
+*   Sample pages using ASP.NET MVC 6
+*   [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side libraries
+*   Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
 
 ## How to
-* [Add a Controller and View](http://go.microsoft.com/fwlink/?LinkID=398600)
-* [Add an appsetting in config and access it in app.](http://go.microsoft.com/fwlink/?LinkID=699562)
-* [Manage User Secrets using Secret Manager.](http://go.microsoft.com/fwlink/?LinkId=699315)
-* [Use logging to log a message.](http://go.microsoft.com/fwlink/?LinkId=699316)
-* [Add packages using NuGet.](http://go.microsoft.com/fwlink/?LinkId=699317)
-* [Add client packages using Bower.](http://go.microsoft.com/fwlink/?LinkId=699318)
-* [Target development, staging or production environment.](http://go.microsoft.com/fwlink/?LinkId=699319)
+
+*   [Add a Controller and View](http://go.microsoft.com/fwlink/?LinkID=398600)
+*   [Add an appsetting in config and access it in app.](http://go.microsoft.com/fwlink/?LinkID=699562)
+*   [Manage User Secrets using Secret Manager.](http://go.microsoft.com/fwlink/?LinkId=699315)
+*   [Use logging to log a message.](http://go.microsoft.com/fwlink/?LinkId=699316)
+*   [Add packages using NuGet.](http://go.microsoft.com/fwlink/?LinkId=699317)
+*   [Add client packages using Bower.](http://go.microsoft.com/fwlink/?LinkId=699318)
+*   [Target development, staging or production environment.](http://go.microsoft.com/fwlink/?LinkId=699319)
 
 ## Overview
-* [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
-* [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
-* [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
-* [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
-* [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)
-* [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=699322)
-* [Read more on the documentation site](http://go.microsoft.com/fwlink/?LinkID=699323)
+
+*   [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
+*   [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
+*   [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
+*   [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
+*   [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)
+*   [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=699322)
+*   [Read more on the documentation site](http://go.microsoft.com/fwlink/?LinkID=699323)
 
 ## Run & Deploy
-* [Run your app](http://go.microsoft.com/fwlink/?LinkID=517851)
-* [Run your app on .NET Core](http://go.microsoft.com/fwlink/?LinkID=517852)
-* [Run commands in your project.json](http://go.microsoft.com/fwlink/?LinkID=517853)
-* [Publish to Microsoft Azure Web Apps](http://go.microsoft.com/fwlink/?LinkID=398609)
 
+*   [Run your app](http://go.microsoft.com/fwlink/?LinkID=517851)
+*   [Run your app on .NET Core](http://go.microsoft.com/fwlink/?LinkID=517852)
+*   [Run commands in your project.json](http://go.microsoft.com/fwlink/?LinkID=517853)
+*   [Publish to Microsoft Azure Web Apps](http://go.microsoft.com/fwlink/?LinkID=398609)
 
 We would love to hear your [feedback](http://go.microsoft.com/fwlink/?LinkId=518015)

--- a/templates/projects/webbasic/README.md
+++ b/templates/projects/webbasic/README.md
@@ -1,36 +1,40 @@
 # Welcome to ASP.NET 5
+
 We've made some big updates in this release, so it’s **important** that you spend a few minutes to learn what’s new.
 
-**You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)**
+You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
 
 ## This application consists of:
-* Sample pages using ASP.NET MVC 6
-* [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side resources
-* Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
+
+*   Sample pages using ASP.NET MVC 6
+*   [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side libraries
+*   Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
 
 ## How to
-* [Add a Controller and View](http://go.microsoft.com/fwlink/?LinkID=398600)
-* [Add an appsetting in config and access it in app.](http://go.microsoft.com/fwlink/?LinkID=699562)
-* [Manage User Secrets using Secret Manager.](http://go.microsoft.com/fwlink/?LinkId=699315)
-* [Use logging to log a message.](http://go.microsoft.com/fwlink/?LinkId=699316)
-* [Add packages using NuGet.](http://go.microsoft.com/fwlink/?LinkId=699317)
-* [Add client packages using Bower.](http://go.microsoft.com/fwlink/?LinkId=699318)
-* [Target development, staging or production environment.](http://go.microsoft.com/fwlink/?LinkId=699319)
+
+*   [Add a Controller and View](http://go.microsoft.com/fwlink/?LinkID=398600)
+*   [Add an appsetting in config and access it in app.](http://go.microsoft.com/fwlink/?LinkID=699562)
+*   [Manage User Secrets using Secret Manager.](http://go.microsoft.com/fwlink/?LinkId=699315)
+*   [Use logging to log a message.](http://go.microsoft.com/fwlink/?LinkId=699316)
+*   [Add packages using NuGet.](http://go.microsoft.com/fwlink/?LinkId=699317)
+*   [Add client packages using Bower.](http://go.microsoft.com/fwlink/?LinkId=699318)
+*   [Target development, staging or production environment.](http://go.microsoft.com/fwlink/?LinkId=699319)
 
 ## Overview
-* [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
-* [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
-* [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
-* [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
-* [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)
-* [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=699322)
-* [Read more on the documentation site](http://go.microsoft.com/fwlink/?LinkID=699323)
+
+*   [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
+*   [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
+*   [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
+*   [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
+*   [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)
+*   [Develop on different platforms](http://go.microsoft.com/fwlink/?LinkID=699322)
+*   [Read more on the documentation site](http://go.microsoft.com/fwlink/?LinkID=699323)
 
 ## Run & Deploy
-* [Run your app](http://go.microsoft.com/fwlink/?LinkID=517851)
-* [Run your app on .NET Core](http://go.microsoft.com/fwlink/?LinkID=517852)
-* [Run commands in your project.json](http://go.microsoft.com/fwlink/?LinkID=517853)
-* [Publish to Microsoft Azure Web Apps](http://go.microsoft.com/fwlink/?LinkID=398609)
 
+*   [Run your app](http://go.microsoft.com/fwlink/?LinkID=517851)
+*   [Run your app on .NET Core](http://go.microsoft.com/fwlink/?LinkID=517852)
+*   [Run commands in your project.json](http://go.microsoft.com/fwlink/?LinkID=517853)
+*   [Publish to Microsoft Azure Web Apps](http://go.microsoft.com/fwlink/?LinkID=398609)
 
 We would love to hear your [feedback](http://go.microsoft.com/fwlink/?LinkId=518015)


### PR DESCRIPTION
This commit changes content of all README.md files
used in web template projects to newer version.
This one is now generated via script written specifically
to parse example html content from aspnet/Templates and
to create Github flavoured Markdown from Project_Readme.html:
http://git.io/vBJBs
The content of generated Markdown file can be seen online:
http://git.io/vBJ4K
This version of Markdown is cleaner and should be better
for users

Under this link you should see the version that hides unimportant white-space changes:
https://github.com/OmniSharp/generator-aspnet/compare/master...peterblazejewicz:update/readme-files?expand=1&w=1

Because the content is fetched from aspnet/Templates, it contains most recent version of their content (so the PR also updates some words within README.md as visible in diff).

Thanks!