### PR TITLE
:art: Add unstable NuGet config option. Closes #183

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,15 +460,16 @@ Produces `/ContactView.cshtml`
 
 ### nuget
 
-Creates a new `NuGet.config` file
+Creates a new `NuGet.config` file. The support for unstable development
+feed is provided by `--unstable` option.
 
 Example:
 
 ```
-yo aspnet:nuget
+yo aspnet:nuget --unstable
 ```
 
-Produces `NuGet.config`
+Produces `NuGet.config` with unstable NuGet feed
 
 [Return to top](#top)
 

--- a/nuget/index.js
+++ b/nuget/index.js
@@ -9,5 +9,11 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createItem = function() {
-  this.generateStandardFile('_nuget.config', 'NuGet.config');
+  // supports unstable feed via optional --unstable cli argument
+  this.generateTemplateFile(
+    '_nuget.config',
+    'NuGet.config', {
+      unstable: (this.options.unstable ? this.options.unstable : false)
+    }
+  );
 };

--- a/templates/_nuget.config
+++ b/templates/_nuget.config
@@ -3,10 +3,7 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear /> line below -->
     <clear />
-    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <!-- uncomment to use another feed for prerelease packages -->
-    <!--
-    <add key="aspnetrelease" value="https://myget.org/f/aspnetrc1/api/v2" />
-    -->
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" /><% if(unstable){ %>
+    <add key="aspnetrelease" value="https://myget.org/f/aspnetrc1/api/v2" /><% } %>
   </packageSources>
 </configuration>

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -97,11 +97,22 @@ describe('Subgenerators without arguments tests', function() {
     util.fileContentCheck(filename, 'Check file content', /api\.nuget\.org/);
   });
 
+  // unstable feed cannot be found in generated file
   describe('aspnet:nuget', function() {
     util.goCreate('nuget');
     var filename = 'NuGet.config';
     util.fileCheck('should create NuGet configuration file', filename);
     util.fileContentCheck(filename, 'Check file content', /api\.nuget\.org/);
+    util.noFileContentCheck(filename, 'Check file content for no unstable feed', /https:\/\/myget\.org\/f\/aspnetrc1\/api\/v2/);
+  });
+
+  // unstable feed should be found in generated file
+  describe('aspnet:nuget --unstable', function() {
+    var arg = '--unstable';
+    var filename = 'NuGet.config';
+    util.goCreateWithArgs('nuget', [arg]);
+    util.fileCheck('should create ' + filename + ' file with unstable feed', filename);
+    util.fileContentCheck(filename, 'Check file content for unstable feed', /https:\/\/myget\.org\/f\/aspnetrc1\/api\/v2/);
   });
 
 });

--- a/test/test-utility.js
+++ b/test/test-utility.js
@@ -158,6 +158,19 @@ var util = (function() {
     });
   }
 
+  /**
+   * The opposite function: specific content cannot be found
+   * in a file assertion
+   * @param  {String} file
+   * @param  {String} message
+   * @param  {String} content
+   * @return {Boolean} true if condition is met
+   */
+  function noFileContentCheck(file, message, content) {
+    it(message, function() {
+      assert.noFileContent(file, content);
+    });
+  }
 
   var methods = {
     goCreateApplication: goCreateApplication,
@@ -169,6 +182,7 @@ var util = (function() {
     dirCheck: dirCheck,
     dirsCheck: dirsCheck,
     fileContentCheck: fileContentCheck,
+    noFileContentCheck: noFileContentCheck,
     makeTempDir: makeTempDir
   };
 


### PR DESCRIPTION
- add conditional option to NuGet subgenerator
- update tests to cover unstable feed generation
- update tests helper to support no-content assertion
- update documention and usage files

With this commit the users will be able to generate NuGet config file
with unstable feed to support pre-release development - e.g. when updating
this generator

The content generated with default option:

```
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <packageSources>
    <!--To inherit the global NuGet package sources remove the <clear /> line below -->
    <clear />
    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
  </packageSources>
</configuration>
```
The content generated with `--unstable` option:
```
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <packageSources>
    <!--To inherit the global NuGet package sources remove the <clear /> line below -->
    <clear />
    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
    <add key="aspnetrelease" value="https://myget.org/f/aspnetrc1/api/v2" />
  </packageSources>
</configuration>
```

I need someone to review this PR:
- is that everything we should add to support pre-release, e.g. 1.0.0-rc2 development?
- is the feed name/path correct?
- is the NuGet file structure OK?

Thanks!
