### PR TITLE
:art: Run Mocha from local dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "mocha": "^2.3.3"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "./node_modules/mocha/bin/mocha ./test"
   }
 }


### PR DESCRIPTION
This commit force using locally installed Mocha to run project tests.
This enforces Mocha version specified in project to be used when running
tests - not globally installed Mocha.
See StrongLoop talk on this subject:
https://youtu.be/u2XCdkL4bWI\?t\=227

After this change `npm test` will be run from local installed NPM module:
```
npm test  

> generator-aspnet@0.0.90 test /Users/piotrblazejewicz/git/generator-aspnet
> ./node_modules/mocha/bin/mocha ./test
```
I'd be happy to test this on Windows OS though (tested OS X)
Thanks!