### PR TITLE
:art: Add CoreCLR option to Docker subgenerator

### DIFF
--- a/Dockerfile/USAGE
+++ b/Dockerfile/USAGE
@@ -1,8 +1,10 @@
 Description:
-    Creates a new Docker configuration file
+    Creates a new Docker configuration file.
+    By default Mono-based definition file is created.
+    To create CoreCLR based definition file use --coreclr option
 
 Example:
-    yo aspnet:Dockerfile
+    yo aspnet:Dockerfile [--coreclr]
 
     This will create:
         Dockerfile

--- a/Dockerfile/index.js
+++ b/Dockerfile/index.js
@@ -9,5 +9,11 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createItem = function() {
-  this.generateStandardFile('Dockerfile.txt', 'Dockerfile');
+  // support CoreCLR runtime version of Docker image
+  // is provided by --coreclr option
+  this.generateTemplateFile(
+    'Dockerfile.txt', 
+    'Dockerfile', {
+      coreclr: (this.options.coreclr) ? this.options.coreclr : false
+  });
 };

--- a/README.md
+++ b/README.md
@@ -232,7 +232,9 @@ Produces `filename.coffee`
 
 ### Dockerfile
 
-Creates a new Docker configuration file
+Creates a new Docker configuration file.
+By default `Mono` based definition file is created.
+To create `CoreCLR` based definition file use `--coreclr` option
 
 Example:
 ```

--- a/app/index.js
+++ b/app/index.js
@@ -105,6 +105,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
       this.applicationName = props.applicationName;
       this.templatedata.guid = guid.v4();
       this.templatedata.grunt = this.options.grunt || false;
+      this.templatedata.coreclr = this.options.coreclr || false;
       done();
     }.bind(this));
   },
@@ -123,7 +124,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
 
         this.template(this.sourceRoot() + '/project.json', this.applicationName + '/project.json', this.templatedata);
 
-        this.copy(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile');
+        this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile', this.templatedata);
 
         /// wwwroot
         this.fs.copy(this.templatePath('wwwroot/**/*'), this.applicationName + '/wwwroot');
@@ -133,7 +134,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
         this.fs.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '/.gitignore');
         this.copy(this.sourceRoot() + '/appsettings.json', this.applicationName + '/appsettings.json');
-        this.copy(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile');
+        this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile', this.templatedata);
         this.fs.copyTpl(this.sourceRoot() + '/Startup.cs', this.applicationName + '/Startup.cs', this.templatedata);
         this.fs.copyTpl(this.sourceRoot() + '/project.json', this.applicationName + '/project.json', this.templatedata);
         this.fs.copy(this.sourceRoot() + '/Properties', this.applicationName + '/Properties');
@@ -150,7 +151,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
           this.fs.copyTpl(this.templatePath('gulpfile.js'), this.applicationName + '/gulpfile.js', this.templatedata);
         }
         // individual files (configs, etc)
-        this.copy(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile');
+        this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile', this.templatedata);
         this.fs.copy(this.templatePath('.bowerrc'), this.applicationName + '/.bowerrc');
         this.fs.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '/.gitignore');
         this.fs.copyTpl(this.templatePath('appsettings.json'), this.applicationName + '/appsettings.json', this.templatedata);
@@ -191,7 +192,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
           this.fs.copyTpl(this.templatePath('gulpfile.js'), this.applicationName + '/gulpfile.js', this.templatedata);
         }
         // individual files (configs, etc)
-        this.copy(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile');
+        this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile', this.templatedata);
         this.fs.copy(this.templatePath('.bowerrc'), this.applicationName + '/.bowerrc');
         this.fs.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '/.gitignore');
         this.fs.copyTpl(this.templatePath('bower.json'), this.applicationName + '/bower.json', this.templatedata);

--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -1,4 +1,4 @@
-FROM microsoft/aspnet:1.0.0-rc1-final
+<% if(!coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-final<% } %><% if(coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-final-coreclr<% } %>
 
 COPY . /app
 WORKDIR /app

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -85,9 +85,19 @@ describe('Subgenerators without arguments tests', function() {
     util.fileCheck('should create tsconfig.json file', 'tsconfig.json');
   });
 
-  describe('aspnet:Dockerfile', function() {
-    util.goCreate('Dockerfile');
-    util.fileCheck('should create Dockerfile', 'Dockerfile');
+  describe('aspnet:Dockerfile Mono-based', function() {
+    var filename = 'Dockerfile';
+    util.goCreate(filename);
+    util.fileCheck('should create Dockerfile', filename);
+    util.fileContentCheck(filename, 'Check the content for Mono-based image tag', /FROM microsoft\/aspnet:1\.0\.0-rc1-final/);
+  });
+
+  describe('aspnet:Dockerfile CoreCLR-based', function() {
+    var arg = '--coreclr';
+    var filename = 'Dockerfile';
+    util.goCreateWithArgs(filename, [arg]);
+    util.fileCheck('should create Dockerfile', filename);
+    util.fileContentCheck(filename, 'Check the content for CoreCLR-based image tag', /FROM microsoft\/aspnet:1\.0\.0-rc1-final-coreclr/);
   });
 
   describe('aspnet:nuget', function() {


### PR DESCRIPTION
There are two base versions of Docker images now:
https://hub.docker.com/r/microsoft/aspnet/

Adding the --coreclr option to Docker subgenerator
allows to create Docker definition file that uses CoreCLR
tag for ASP.NET Docker image.
By default Mono based tag
is used by this subgenerator - the same as default image
tag for ASP.NET image:
https://hub.docker.com/r/microsoft/aspnet/

```
FROM microsoft/aspnet:1.0.0-rc1-final

COPY . /app
WORKDIR /app
RUN ["dnu", "restore"]

EXPOSE 5000/tcp
ENTRYPOINT ["dnx", "-p", "project.json", "web"]
```
```
FROM microsoft/aspnet:1.0.0-rc1-final-coreclr

COPY . /app
WORKDIR /app
RUN ["dnu", "restore"]

EXPOSE 5000/tcp
ENTRYPOINT ["dnx", "-p", "project.json", "web"]
```

Thanks!