### PR TITLE
Add xUnit sample test subgenerator. Closes #528

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The alphabetic list of available sub generators (_to create files after the proj
 * [aspnet:tfignore](#tfignore)
 * [aspnet:TypeScript](#typescript)
 * [aspnet:TypeScriptConfig](#typescriptconfig)
+* [aspnet:xunit](#xunit)
 * [aspnet:WebApiContoller](#webapicontroller)
 
 ** Note: files generated are created in the working directory, no conventions are forced **
@@ -612,6 +613,20 @@ yo aspnet:TypeScriptConfig
 ```
 
 Produces `tsconfig.json`
+
+[Return to top](#top)
+
+### xunit
+
+Creates a new xUnit sample test file
+
+Example:
+
+```
+yo aspnet:xunit SampleTest
+```
+
+Produces `SampleTest.cs`
 
 [Return to top](#top)
 

--- a/app/USAGE
+++ b/app/USAGE
@@ -37,4 +37,5 @@ Subgenerators:
   yo aspnet:tfignore [options]
   yo aspnet:TypeScript [options] <name>
   yo aspnet:TypeScriptConfig [options] <name>
+  yo aspnet:xunit [options] <name>
   yo aspnet:WebApiController [options] <name>

--- a/templates/xunit.cs
+++ b/templates/xunit.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace <%= namespace %>
+{
+    public class <%= classname %>
+    {
+        [Fact]
+        public void TestMethod1()
+        {
+        }
+    }
+}

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -439,6 +439,22 @@ describe('Subgenerators with named arguments tests', function() {
     util.fileCheck('should create ' + filename + ' file', filename);
   });
 
+  describe('aspnet:xunit', function() {
+    var arg = 'SampleTest';
+    var filename = 'SampleTest.cs';
+    util.goCreateWithArgs('xunit', [arg]);
+    util.fileCheck('should create ' + filename + ' file', filename);
+  });
+
+  describe('aspnet:xunit in cwd of project.json', function() {
+    var arg = 'SampleTest';
+    var filename = 'SampleTest.cs';
+    var dir = util.makeTempDir();
+    util.goCreateApplication('web', 'webTest', dir);
+    util.goCreateWithArgs('xunit', [arg], path.join(dir, 'webTest'));
+    util.fileCheck('should create ' + filename + ' file', filename);
+  });
+
   describe('aspnet:WebApiController', function() {
     var arg = 'file';
     var filename = 'file.cs';

--- a/xunit/USAGE
+++ b/xunit/USAGE
@@ -1,0 +1,8 @@
+Description:
+	Creates a new xUnit sample test file
+
+Example:
+	yo aspnet:xunit SampleTest
+
+	This will create:
+		SampleTest.cs

--- a/xunit/index.js
+++ b/xunit/index.js
@@ -1,0 +1,19 @@
+'use strict';
+var util = require('util');
+var ScriptBase = require('../script-base.js');
+
+var NamedGenerator = module.exports = function NamedGenerator() {
+  ScriptBase.apply(this, arguments);
+};
+
+util.inherits(NamedGenerator, ScriptBase);
+
+NamedGenerator.prototype.createNamedItem = function() {
+  this.generateTemplateFile(
+    'xunit.cs',
+    this.name + '.cs', {
+      namespace: this.namespace(),
+      classname: this.name
+    }
+  );
+};


### PR DESCRIPTION
Hi,

This commit adds a empty xUnit test class content subgenerator to the project.
We ship xUnit sample project generator, but there was no way to actually add another test into such project.
This commit fixes this problem.

The original idea is taken from a VS add-on by @jsakamoto:
https://visualstudiogallery.msdn.microsoft.com/403d0fe1-a0ea-4365-b158-38b2b1a3d9c0

The default `using` are based on `Class` template content with required xUnit import added.

This PR is covered with tests and updates documentation. The implementation supports namespacing based on `project.json`.

Thanks!