### PR TITLE
Issue #525 - Install sqlite3 at version required by EntityFramework.

### DIFF
--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -1,5 +1,8 @@
 <% if(!coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-final<% } %><% if(coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-final-coreclr<% } %>
 
+RUN printf "deb http://ftp.us.debian.org/debian jessie main\n" >> /etc/apt/sources.list
+RUN apt-get -qq update && apt-get install -qqy sqlite3 libsqlite3-dev && rm -rf /var/lib/apt/lists/*
+
 COPY . /app
 WORKDIR /app
 RUN ["dnu", "restore"]


### PR DESCRIPTION
In order to address an issue with running a sqlite3 database on aspnet-docker-linux
a version of sqlite3 must be installed that is greater than or equal to 3.7.15
which is not available on the default apt sources list in this image.
ref: 	https://github.com/aspnet/EntityFramework/issues/3089
	https://github.com/aspnet/aspnet-docker/issues/121