### PR TITLE
Issue #527 - Greatly improve rebuild times for docker images ...

### DIFF
--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -1,8 +1,9 @@
 <% if(!coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-final<% } %><% if(coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-final-coreclr<% } %>
 
-COPY . /app
+COPY ./project.json /app/project.json
 WORKDIR /app
 RUN ["dnu", "restore"]
+COPY . /app
 
 EXPOSE 5000/tcp
 ENTRYPOINT ["dnx", "-p", "project.json", "web"]


### PR DESCRIPTION
...with unchanged dependencies.

The reason we copy the project.json first is related to the way that 
Docker's "union file system" works. Each command in sequence gets cached 
on the docker host as a binary. Commands that are "unchanged" from the
previous run will not be run a second time.

By changing the order here, docker's "restart" of a container will only
run a full nuget restore when a project's dependencies change, as opposed 
to when any code changes at all.
