### PR TITLE
:white_check_mark: Add tests to check for FQCN

### DIFF
--- a/test/test-core.js
+++ b/test/test-core.js
@@ -46,6 +46,10 @@ describe('aspnet - Empty Application', function() {
     }
   });
 
+  describe('Checking FQCN when using WebApplication.Run', function() {
+    util.fileContentCheck('emptyTest/Startup.cs', 'file contains FQCN check', /Microsoft\.AspNet\.Hosting\.WebApplication\.Run/);
+  });
+
 });
 
 /*
@@ -326,6 +330,10 @@ describe('aspnet - Web Application', function() {
     }
   });
 
+  describe('Checking FQCN when using WebApplication.Run', function() {
+    util.fileContentCheck('webTest/Startup.cs', 'file contains FQCN check', /Microsoft\.AspNet\.Hosting\.WebApplication\.Run/);
+  });
+
 });
 
 /*
@@ -457,6 +465,9 @@ describe('aspnet - Web Application Basic', function() {
     }
   });
 
+  describe('Checking FQCN when using WebApplication.Run', function() {
+    util.fileContentCheck('webTest/Startup.cs', 'file contains FQCN check', /Microsoft\.AspNet\.Hosting\.WebApplication\.Run/);
+  });
 });
 
 /*
@@ -501,6 +512,10 @@ describe('aspnet - Web API Application', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+  });
+
+  describe('Checking FQCN when using WebApplication.Run', function() {
+    util.fileContentCheck('webAPITest/Startup.cs', 'file contains FQCN check', /Microsoft\.AspNet\.Hosting\.WebApplication\.Run/);
   });
 
 });


### PR DESCRIPTION
This commit adds checks to cover use of FQCN in Startup.cs
as generator-aspnet uses that custom patch, compared to aspnet/Templates
https://github.com/aspnet/Hosting/issues/482
https://github.com/OmniSharp/generator-aspnet/issues/488
https://github.com/OmniSharp/generator-aspnet/pull/491
This added test coverage should prevent unintentional regression change
when changes are ported from aspnet/Templates to generator-aspnet.

Thanks!