### PR TITLE
:arrow_up: Update Dockerfile to rc1-update1 tag. Closes #533

### DIFF
--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -1,4 +1,4 @@
-<% if(!coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-final<% } %><% if(coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-final-coreclr<% } %>
+<% if(!coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-update1<% } %><% if(coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-update1-coreclr<% } %>
 
 RUN printf "deb http://ftp.us.debian.org/debian jessie main\n" >> /etc/apt/sources.list
 RUN apt-get -qq update && apt-get install -qqy sqlite3 libsqlite3-dev && rm -rf /var/lib/apt/lists/*

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -89,7 +89,7 @@ describe('Subgenerators without arguments tests', function() {
     var filename = 'Dockerfile';
     util.goCreate(filename);
     util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for Mono-based image tag', /FROM microsoft\/aspnet:1\.0\.0-rc1-final/);
+    util.fileContentCheck(filename, 'Check the content for Mono-based image tag', /FROM microsoft\/aspnet:1\.0\.0-rc1-update1/);
   });
 
   describe('aspnet:Dockerfile CoreCLR-based', function() {
@@ -97,7 +97,7 @@ describe('Subgenerators without arguments tests', function() {
     var filename = 'Dockerfile';
     util.goCreateWithArgs(filename, [arg]);
     util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for CoreCLR-based image tag', /FROM microsoft\/aspnet:1\.0\.0-rc1-final-coreclr/);
+    util.fileContentCheck(filename, 'Check the content for CoreCLR-based image tag', /FROM microsoft\/aspnet:1\.0\.0-rc1-update1-coreclr/);
   });
 
   describe('aspnet:nuget', function() {


### PR DESCRIPTION
This commits updates tags used for official aspnet-dockerfile
images.
See: http://git.io/vRNjH

The content is tested with generated WebApplication template (which uses SQLite) and Docker 1.9.1:
```
docker build -t webapp .
Sending build context to Docker daemon 255.5 kB
Step 1 : FROM microsoft/aspnet:1.0.0-rc1-update1
1.0.0-rc1-update1: Pulling from microsoft/aspnet

789f6c797444: Pull complete 
...
```
```
docker build -t webapp .            
Sending build context to Docker daemon 255.5 kB
Step 1 : FROM microsoft/aspnet:1.0.0-rc1-update1-coreclr
1.0.0-rc1-update1-coreclr: Pulling from microsoft/aspnet
ec73306ee200: Pull complete 
...
```
Thanks!