### PR TITLE
Delete grunt default task from web templates

### DIFF
--- a/templates/projects/web/Gruntfile.js
+++ b/templates/projects/web/Gruntfile.js
@@ -4,22 +4,5 @@
 
 module.exports = function(grunt) {
   grunt.initConfig({
-    bower: {
-      install: {
-        options: {
-          targetDir: "wwwroot/lib",
-          layout: "byComponent",
-          cleanTargetDir: false,
-          copy: false
-        }
-      }
-    }
   });
-
-  // This command registers the default task which will install bower packages into wwwroot/lib
-  grunt.registerTask("default", ["bower:install"]);
-
-  // The following line loads the grunt plugins.
-  // This line needs to be at the end of this this file.
-  grunt.loadNpmTasks("grunt-bower-task");
 };

--- a/templates/projects/web/package.json
+++ b/templates/projects/web/package.json
@@ -7,7 +7,6 @@
     "gulp-cssmin": "0.1.7",
     "gulp-uglify": "1.2.0",
     "rimraf": "2.2.8"<% } %><% if(grunt){ %>
-    "grunt": "0.4.5",
-    "grunt-bower-task": "0.4.0"<% } %>
+    "grunt": "0.4.5"<% } %>
   }
 }

--- a/templates/projects/web/project.json
+++ b/templates/projects/web/project.json
@@ -53,7 +53,7 @@
   "scripts": {
     "prepublish": [
       "npm install",
-      "bower install",<% if(!grunt){ %>
+      "bower install"<% if(!grunt){ %>,
       "gulp clean",
       "gulp min"<% } %>
     ]

--- a/templates/projects/web/project.json
+++ b/templates/projects/web/project.json
@@ -55,8 +55,7 @@
       "npm install",
       "bower install",<% if(!grunt){ %>
       "gulp clean",
-      "gulp min"<% } %><% if(grunt){ %>
-      "grunt default"<% } %>
+      "gulp min"<% } %>
     ]
   }
 }

--- a/templates/projects/webbasic/Gruntfile.js
+++ b/templates/projects/webbasic/Gruntfile.js
@@ -4,22 +4,5 @@
 
 module.exports = function(grunt) {
   grunt.initConfig({
-    bower: {
-      install: {
-        options: {
-          targetDir: "wwwroot/lib",
-          layout: "byComponent",
-          cleanTargetDir: false,
-          copy: false
-        }
-      }
-    }
   });
-
-  // This command registers the default task which will install bower packages into wwwroot/lib
-  grunt.registerTask("default", ["bower:install"]);
-
-  // The following line loads the grunt plugins.
-  // This line needs to be at the end of this this file.
-  grunt.loadNpmTasks("grunt-bower-task");
 };

--- a/templates/projects/webbasic/package.json
+++ b/templates/projects/webbasic/package.json
@@ -7,7 +7,6 @@
     "gulp-cssmin": "0.1.7",
     "gulp-uglify": "1.2.0",
     "rimraf": "2.2.8"<% } %><% if(grunt){ %>
-    "grunt": "0.4.5",
-    "grunt-bower-task": "0.4.0"<% } %>
+    "grunt": "0.4.5"<% } %>
   }
 }

--- a/templates/projects/webbasic/project.json
+++ b/templates/projects/webbasic/project.json
@@ -48,9 +48,7 @@
       "npm install",
       "bower install",<% if(!grunt){ %>
       "gulp clean",
-      "gulp min"<% } %><% if(grunt){ %>
-      "grunt default"
-      <% } %>
+      "gulp min"<% } %>
     ]
   }
 }

--- a/templates/projects/webbasic/project.json
+++ b/templates/projects/webbasic/project.json
@@ -46,7 +46,7 @@
   "scripts": {
     "prepublish": [
       "npm install",
-      "bower install",<% if(!grunt){ %>
+      "bower install"<% if(!grunt){ %>,
       "gulp clean",
       "gulp min"<% } %>
     ]


### PR DESCRIPTION
There's a subtle problem with the Grunt/Bower implementation of the web projects which are scaffolded when running `yo aspnet --grunt`. The `project.json` file defines `grunt default` in its array of `prepublish` commands. This command immediately follows `bower install`. Upon closer inspection, we see that `bower install` and `grunt default` are accomplishing the same exact thing. I proved this out by running the 2 commands separately and then comparing the results. Consequently, this PR removes the Grunt default task completely.