### PR TITLE
Fix broken links in Gruntfile.js files

### DIFF
--- a/templates/Gruntfile.js
+++ b/templates/Gruntfile.js
@@ -1,6 +1,6 @@
 /*
-  This file in the main entry point for defining grunt tasks and using grunt plugins.
-  Click here to learn more. http://go.microsoft.com/fwlink/?LinkID=513275&clcid=0x409
+  This file is the main entry point for defining grunt tasks and using grunt plugins.
+  Click here to learn more: https://docs.asp.net/en/latest/client-side/using-grunt.html
 */
 "use strict";
 

--- a/templates/projects/web/Gruntfile.js
+++ b/templates/projects/web/Gruntfile.js
@@ -1,5 +1,7 @@
-// This file in the main entry point for defining grunt tasks and using grunt plugins.
-// Click here to learn more. http://go.microsoft.com/fwlink/?LinkID=513275&clcid=0x409
+/*
+  This file is the main entry point for defining grunt tasks and using grunt plugins.
+  Click here to learn more: https://docs.asp.net/en/latest/client-side/using-grunt.html
+*/
 "use strict";
 
 module.exports = function(grunt) {

--- a/templates/projects/webbasic/Gruntfile.js
+++ b/templates/projects/webbasic/Gruntfile.js
@@ -1,5 +1,7 @@
-// This file in the main entry point for defining grunt tasks and using grunt plugins.
-// Click here to learn more. http://go.microsoft.com/fwlink/?LinkID=513275&clcid=0x409
+/*
+  This file is the main entry point for defining grunt tasks and using grunt plugins.
+  Click here to learn more: https://docs.asp.net/en/latest/client-side/using-grunt.html
+*/
 "use strict";
 
 module.exports = function(grunt) {


### PR DESCRIPTION
The link listed at the top of each of the 3 Gruntfile.js files was broken. I updated it to the correct link on docs.asp.net. Also, I enforced consistency by making all 3 files use the same multi-line style comment. While I was at it, I fixed a minor typo in the comment as well.