### PR TITLE
:bug: Fix missing emitEntryPoint key

### DIFF
--- a/templates/projects/console/project.json
+++ b/templates/projects/console/project.json
@@ -5,6 +5,11 @@
   "tags": [ "" ],
   "projectUrl": "",
   "licenseUrl": "",
+
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+
   "tooling": {
     "defaultNamespace": "<%= namespace %>"
   },


### PR DESCRIPTION
This commit fixes missing `emitEntryPoint` key in `project.json`:
The emitEntryPoint key is crucial to fill
applicaton configuration at runtime:
http://git.io/v0E1o
http://git.io/v0E1p

Thanks!