### PR TITLE
Add new TypeScriptJSX sub-generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,20 @@ Produces `tsconfig.json`
 
 [Return to top](#top)
 
+### TypeScriptJSX
+
+Creates a new JSX-enabled TypeScript file
+
+Example:
+
+```
+yo aspnet:TypeScriptJSX filename
+```
+
+Produces `filename.tsx`
+
+[Return to top](#top)
+
 ### WebApiController
 
 Creates a new ASP.NET 5 WebApiController class

--- a/TypeScriptJSX/USAGE
+++ b/TypeScriptJSX/USAGE
@@ -1,0 +1,8 @@
+Description:
+	Creates a new JSX-enabled TypeScript file
+
+Example:
+	yo aspnet:TypeScriptJSX filename
+
+	This will create:
+		filename.tsx

--- a/TypeScriptJSX/index.js
+++ b/TypeScriptJSX/index.js
@@ -1,0 +1,16 @@
+'use strict';
+var util = require('util');
+var ScriptBase = require('../script-base.js');
+
+var NamedGenerator = module.exports = function NamedGenerator() {
+  ScriptBase.apply(this, arguments);
+};
+
+util.inherits(NamedGenerator, ScriptBase);
+
+NamedGenerator.prototype.createNamedItem = function() {
+  this.generateTemplateFile(
+    'TypeScriptJSX.tsx',
+    this.name + '.tsx'
+  );
+};

--- a/templates/TypeScriptJSX.tsx
+++ b/templates/TypeScriptJSX.tsx
@@ -1,0 +1,3 @@
+// A '.tsx' file enables JSX support in the TypeScript compiler, 
+// for more information see the following page on the TypeScript wiki:
+// https://github.com/Microsoft/TypeScript/wiki/JSX

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -438,6 +438,13 @@ describe('Subgenerators with named arguments tests', function() {
     util.goCreateWithArgs('TypeScript', [arg]);
     util.fileCheck('should create ' + filename + ' file', filename);
   });
+  
+  describe('aspnet:TypeScriptJSX', function() {
+    var arg = 'file';
+    var filename = 'file.tsx';
+    util.goCreateWithArgs('TypeScriptJSX', [arg]);
+    util.fileCheck('should create ' + filename + ' file', filename);
+  });  
 
   describe('aspnet:WebApiController', function() {
     var arg = 'file';


### PR DESCRIPTION
TypeScript 1.6 introduced the `.tsx` file extension for supporting JSX within a TypeScript file. This PR addresses issue https://github.com/OmniSharp/generator-aspnet/issues/540 by adding a sub-generator for this new TypeScript JSX file type.