### PR TITLE
:bug: Fix project name in navbar

### DIFF
--- a/templates/projects/webbasic/Views/Shared/_Layout.cshtml
+++ b/templates/projects/webbasic/Views/Shared/_Layout.cshtml
@@ -26,7 +26,7 @@
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                     </button>
-                    <a asp-controller="Home" asp-action="Index" class="navbar-brand">WebApplicationBasic</a>
+                    <a asp-controller="Home" asp-action="Index" class="navbar-brand"><%= namespace %></a>
                 </div>
                 <div class="navbar-collapse collapse">
                     <ul class="nav navbar-nav">


### PR DESCRIPTION
The project name should be dynamic based on user input.
Instead WebStarter (WebBasic) template used fixed name.
This commit fixes this problem. Both web templates should
use dynamic name in NavBar brand section

Thanks!