### PR TITLE
:art: Add UserSecrets subgenerator. Closes #303

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The alphabetic list of available sub generators (_to create files after the proj
 * [aspnet:TypeScript](#typescript)
 * [aspnet:TypeScriptConfig](#typescriptconfig)
 * [aspnet:TypeScriptJSX](#typescriptjsx)
+* [aspnet:UserSecrets](#usersecrets)
 * [aspnet:WebApiContoller](#webapicontroller)
 
 ** Note: files generated are created in the working directory, no conventions are forced **
@@ -627,6 +628,24 @@ yo aspnet:TypeScriptJSX filename
 ```
 
 Produces `filename.tsx`
+
+[Return to top](#top)
+
+### UserSecrets
+
+Adds UserSecrets information to ASP.NET5 `project.json` file.
+The generator do not update existing keys if found and does
+not create new `project.json` file.
+
+Example:
+
+```
+yo aspnet:UserSecrets
+```
+
+This will add following keys to project.json:
+- "userSecretsId" key
+- "Microsoft.Extensions.Configuration.UserSecrets" key under "dependencies"
 
 [Return to top](#top)
 

--- a/UserSecrets/USAGE
+++ b/UserSecrets/USAGE
@@ -1,0 +1,11 @@
+Description:
+  Adds UserSecrets information to ASP.NET5 project.json file
+  The generator do not update existing keys if found and does
+  not create new project.json file
+
+Example:
+	yo aspnet:UserSecrets
+
+	This will add following keys to project.json:
+    - "userSecretsId" key
+    - "Microsoft.Extensions.Configuration.UserSecrets" key under "dependencies"

--- a/UserSecrets/index.js
+++ b/UserSecrets/index.js
@@ -1,0 +1,143 @@
+'use strict';
+var chalk = require('chalk');
+var Configuration = require('../configuration');
+var green = chalk.green;
+var nConf = require('nconf');
+var red = chalk.bold.red;
+var ScriptBase = require('../script-base-basic.js');
+var util = require('util');
+var uuid = require('uuid');
+var yellow = chalk.yellow;
+
+var Generator = module.exports = function Generator() {
+  ScriptBase.apply(this, arguments);
+};
+
+util.inherits(Generator, ScriptBase);
+
+/**
+ * A task done by this generator
+ * Searches for project.json and adds UserSecrets
+ * required configuration keys:
+ * - userSecretsId
+ * - dependency entry
+ */
+Generator.prototype.createItem = function() {
+  var project = this._getProject();
+  if (!project) {
+    return;
+  }
+  // #1 add (but not update): userSecretsId key with new hash
+  var userSecetIdUpdated = this._updateUserSecretsId(project);
+  // #2 add (but not update): NuGet UserSecrets package dependency
+  var depsUpdated = this._updateDependencies(project);
+  // if there was a change in project flush changes back to disk
+  if (userSecetIdUpdated || depsUpdated) {
+    this.log('Writing changes back to project.json file');
+    var self = this;
+    project.save(this._projectPath, function(error) {
+      if (error) {
+        self.log(red('Error when updating project.json file!'));
+        self.log(red(error));
+        return;
+      }
+      self.log(green('All done! The changes were saved to project file.'));
+      var USER_SECRETS_DOCS = 'https://docs.asp.net/en/latest/security/app-secrets.html';
+      self.log("For more information about UserSecrets please visit: %s", yellow(USER_SECRETS_DOCS));
+    });
+  } else {
+    this.log(green('All done! No changes were made.'));
+  }
+};
+
+Generator.prototype._projectPath = null;
+/**
+ * Creates unique hash for ASP.NET5 userSecretId key
+ * @return {String} unique hash token
+ */
+Generator.prototype._generateUserSecretId = function() {
+  var HASH_PREFIX = 'aspnet5';
+  var namespace = this.namespace();
+  var guid = uuid.v4();
+  var userSecretId = util.format('%s-%s-%s', HASH_PREFIX, namespace, guid);
+  return userSecretId || '';
+};
+
+/**
+ * Reads projects.json and returns an object
+ * via {nconfg} store
+ * @return {nconfg} a project
+ */
+Generator.prototype._getProject = function() {
+  // get path to project.json using extensions
+  this._projectPath = Configuration.getProjectJsonPath();
+  // no-op if project.json is not found
+  if (this._projectPath === null) {
+    this.log(red('Cannot find project.json file!'));
+    this.log('You need to invoke this generator from within an ASP.NET 5 project');
+    return null;
+  }
+  this.log("project.json found: %s", green(this._projectPath));
+  // The adding UserSecrets is two step process:
+  // both require that we load project.json, make changes and save it back
+  var project = nConf.file({
+    file: this._projectPath
+  });
+  return project;
+};
+
+/**
+ * Updates userSecretsId key in project file
+ * @param  {Object} project representation with nconf store
+ * @return {Boolean} true, if userSecretsId key has been updated
+ */
+Generator.prototype._updateUserSecretsId = function(project) {
+  if (!project) {
+    return false;
+  }
+  var updated = false;
+  var USER_SECRETS_ID_KEY = 'userSecretsId';
+  // do not update existing userSecretsId keys!
+  var currentUserSecretId = project.get(USER_SECRETS_ID_KEY);
+  if (currentUserSecretId) {
+    this.log('Existing %s found with value: %s', USER_SECRETS_ID_KEY, green(currentUserSecretId));
+    this.log('Adding %s key: %s', USER_SECRETS_ID_KEY, yellow("skipped"));
+  } else {
+    var newUserSecretIdValue = this._generateUserSecretId();
+    updated = project.set(USER_SECRETS_ID_KEY, newUserSecretIdValue);
+    if (updated === false) {
+      this.log('Adding %s: %s %s', USER_SECRETS_ID_KEY, newUserSecretIdValue, red("failure"));
+    } else {
+      this.log('Adding %s: %s %s', USER_SECRETS_ID_KEY, newUserSecretIdValue, green("success"));
+    }
+  }
+  return updated;
+};
+
+/**
+ * Updates project dependencies with UserSecrets
+ * @param  {Object} project representation with nconf store
+ * @return {Boolean} true, if project dependencies has been updated
+ */
+Generator.prototype._updateDependencies = function(project) {
+  if (!project) {
+    return false;
+  }
+  var updated = false;
+  var USER_SECRETS_NUGET_PACKAGE_KEY = 'dependencies:Microsoft.Extensions.Configuration.UserSecrets';
+  var USER_SECRETS_NUGET_VERSION = '1.0.0-rc1-final';
+  // do not update existing userSecretsId keys!
+  var currentUserSecretsDependency = project.get(USER_SECRETS_NUGET_PACKAGE_KEY);
+  if (currentUserSecretsDependency) {
+    this.log('Existing %s found with value: %s', USER_SECRETS_NUGET_PACKAGE_KEY, green(currentUserSecretsDependency));
+    this.log('Adding %s key: %s', USER_SECRETS_NUGET_PACKAGE_KEY, yellow("skipped"));
+  } else {
+    updated = project.set(USER_SECRETS_NUGET_PACKAGE_KEY, USER_SECRETS_NUGET_VERSION);
+    if (updated === false) {
+      this.log('Adding %s: %s %s', USER_SECRETS_NUGET_PACKAGE_KEY, USER_SECRETS_NUGET_VERSION, red("failure"));
+    } else {
+      this.log('Adding %s: %s %s', USER_SECRETS_NUGET_PACKAGE_KEY, USER_SECRETS_NUGET_VERSION, green("success"));
+    }
+  }
+  return updated;
+};

--- a/app/USAGE
+++ b/app/USAGE
@@ -38,4 +38,5 @@ Subgenerators:
   yo aspnet:TypeScript [options] <name>
   yo aspnet:TypeScriptConfig [options] <name>
   yo aspnet:TypeScriptJSX [options] <name>
+  yo aspnet:UserSecrets [options] <name>
   yo aspnet:WebApiController [options] <name>

--- a/package.json
+++ b/package.json
@@ -50,12 +50,14 @@
     "chai": "^3.3.0",
     "chalk": "^1.0.0",
     "findup-sync": "^0.3.0",
+    "nconf": "^0.8.2",
     "uuid": "^2.0.1",
     "vs_projectname": "^1.0.0",
     "yeoman-generator": "^0.19.0",
     "yosay": "^1.0.0"
   },
   "devDependencies": {
+    "mkdirp": "^0.5.1",
     "mocha": "^2.3.3"
   },
   "scripts": {

--- a/test/usersecrets.js
+++ b/test/usersecrets.js
@@ -1,0 +1,181 @@
+'use strict';
+
+var assert = require('yeoman-generator').assert;
+var helpers = require('yeoman-generator').test;
+var mkdirp = require('mkdirp');
+var nconf = require('nconf');
+var path = require('path');
+var util = require('./test-utility');
+var yeoman = require('yeoman-generator');
+
+/**
+ * Sets of tests to validate aspnet:UserSecrets generator
+ * Below tests are created in separate file because of problem
+ * with testing nested generators invocations with existing helpers from
+ * util package (test-utility.js). See comments in implementation below
+ * @todo use assert.JSONFileContent() from updated yeoman-generator
+ */
+describe('aspnet:UserSecrets', function() {
+
+  var USER_SECRETS_ID_KEY = 'userSecretsId';
+  var USER_SECRETS_NUGET_PACKAGE_KEY = 'dependencies:Microsoft.Extensions.Configuration.UserSecrets';
+
+  /**
+   * Slightly modified version of runtime Yo testDirectory
+   * features - this one make sure that directory is created
+   * which is missing in original swap trick
+   * @credit @david-driscoll
+   * @see ./test-utility.js
+   */
+  var oldTestDirectory;
+  after(function() {
+    helpers.testDirectory = oldTestDirectory;
+  });
+  before(function() {
+    oldTestDirectory = helpers.testDirectory;
+    yeoman.test.testDirectory = function(dir, cb) {
+      dir = path.resolve(dir);
+      mkdirp.sync(dir);
+      process.chdir(dir);
+      cb();
+    };
+  });
+
+  /**
+   * We are in directory witout ASP.NET5 project.json
+   * We don't want to create any artefacts after running UserSecrets
+   * that is: make sure we don't create project.json
+   */
+  describe('It does not create any file artefacts when called in directory without project.json', function() {
+    before(function(done) {
+      var tempDir = util.makeTempDir();
+      helpers.run(require.resolve('../UserSecrets'))
+        .inDir(tempDir)
+        .on('end', function() {
+          done();
+        });
+    });
+
+    it('there is no project.json created in current directory', function() {
+      assert.noFile('project.json');
+    });
+
+  });
+
+  /**
+   * When we are in directory with ASP.NET5 project.json
+   * make sure we are not overriding existing keys - as with web template
+   * which already comes with UserSecrets implementation.
+   * That is: don't mess with existing project.json
+   */
+  describe('It does not override existing keys in project.json', function() {
+    var existingUserSecretId = null,
+      existingPackageVersion = null;
+    before(function(done) {
+      var tempDir = util.makeTempDir();
+      helpers.run(require.resolve('../app'))
+        .withPrompts({
+          type: 'web',
+          applicationName: 'webTest'
+        })
+        .inDir(tempDir)
+        .on('end', function() {
+          var targetDir = path.join(tempDir, 'webTest/');
+          process.chdir(targetDir);
+          nconf.remove('file');
+          nconf.file({
+            file: './project.json'
+          });
+          // store existing values
+          existingUserSecretId = nconf.get(USER_SECRETS_ID_KEY);
+          existingPackageVersion = nconf.get(USER_SECRETS_NUGET_PACKAGE_KEY);
+          assert.ok(existingUserSecretId, 'userSecretId is not null');
+          assert.ok(existingPackageVersion, 'packageVersion is not null');
+          helpers.run(require.resolve('../UserSecrets'))
+            .inDir(targetDir)
+            .on('end', function() {
+              // reset project reprentation
+              nconf.remove('file');
+              nconf.file({
+                file: './project.json'
+              });
+              done();
+            });
+        });
+    });
+
+    it('There is a project.json file already created', function() {
+      assert.file('project.json');
+    });
+
+    it('The userSecretId key is not overriden', function() {
+      assert.equal(existingUserSecretId, nconf.get(USER_SECRETS_ID_KEY));
+    });
+
+    it('the UserSecrets nuget package version is not changed', function() {
+      assert.equal(existingPackageVersion, nconf.get(USER_SECRETS_NUGET_PACKAGE_KEY));
+    });
+
+  });
+
+  /**
+   * When we are in directory with existing ASP.NET5 project and there is
+   * no UserSupport added to project make sure that required keys are added
+   * and values are at least formatted as expected or have correct values
+   */
+  describe('It creates expected keys in project.json', function() {
+    var existingUserSecretId = null,
+      existingPackageVersion = null;
+    before(function(done) {
+      var tempDir = util.makeTempDir();
+      helpers.run(require.resolve('../app'))
+        .withPrompts({
+          type: 'empty',
+          applicationName: 'emptyTest'
+        })
+        .inDir(tempDir)
+        .on('end', function() {
+          var targetDir = path.join(tempDir, 'emptyTest/');
+          process.chdir(targetDir);
+          nconf.remove('file');
+          nconf.file({
+            file: './project.json'
+          });
+          // store existing values - expected to be falsy
+          existingUserSecretId = nconf.get(USER_SECRETS_ID_KEY);
+          existingPackageVersion = nconf.get(USER_SECRETS_NUGET_PACKAGE_KEY);
+          assert.equal(undefined, existingUserSecretId, 'userSecretId is null');
+          assert.equal(undefined, existingPackageVersion, 'packageVersion is null');
+          helpers.run(require.resolve('../UserSecrets'))
+            .inDir(targetDir)
+            .on('end', function() {
+              // reset project reprentation
+              nconf.remove('file');
+              nconf.file({
+                file: './project.json'
+              });
+              done();
+            });
+        });
+    });
+
+    it('There is a project.json file already created', function() {
+      assert.file('project.json');
+    });
+
+    it('The userSecretId key is added', function() {
+      assert.ok(nconf.get(USER_SECRETS_ID_KEY));
+    });
+
+    it('The correctly formatted userSecretId value is added', function() {
+      assert.fileContent('./project.json', /aspnet5-emptyTest/);
+    });
+
+    it('the UserSecrets nuget package version is added', function() {
+      assert.fileContent('./project.json', /Microsoft\.Extensions\.Configuration\.UserSecrets/);
+      assert.fileContent('./project.json', /1\.0\.0-rc1-final/);
+    });
+
+  });
+
+});


### PR DESCRIPTION
> **NOTICE**: Make sure to update NPM dependencies before running tests with this PR!

This commit introduces UserSecrets subgenerator.
The subgenerator is envisioned as a helper tool that
enhances existing ASP.NET5 projects by adding UserSecrets
support only when existing project.json file has no one already
added. That way there is no dependency on UserSecrets implementation
in aspnet/Templates upstream project.
The set of features introduced by this commit:
- aspnet:UserSecrets subgenerator
- project NPM dependency updates
- test updates to provide UserSecrets coverage
- documentation and usage update
The updated documentation used by this subgenerator provides link
to relevant section of docs.asp.net


Usage:
```
yo aspnet:UserSecrets
```

Invoking from empty folder:
```
development  yo aspnet:UserSecrets
Cannot find project.json file!
You need to invoke this generator from within an ASP.NET 5 project
```

Invoking from folder with `project.json` that already has support for UserSecrets added:
```
➜  WebApplication  yo aspnet:UserSecrets
project.json found: /Users/piotrblazejewicz/development/WebApplication/project.json
Existing userSecretsId found with value: aspnet5-WebApplication-d9126313-91cc-4a4d-990d-7f18a42d998f
Adding userSecretsId key: skipped
Existing dependencies:Microsoft.Extensions.Configuration.UserSecrets found with value: 1.0.0-rc1-final
Adding dependencies:Microsoft.Extensions.Configuration.UserSecrets key: skipped
All done! No changes were made.
```

Invoking from folder with `project.json` that has no support for UserSecrets added yet:
```
➜  WebApplicationBasic  yo aspnet:UserSecrets
project.json found: /Users/piotrblazejewicz/development/WebApplicationBasic/project.json
Adding userSecretsId: aspnet5-WebApplicationBasic-669fc6d3-d192-4845-a1b6-a7f21b8950d9 success
Adding dependencies:Microsoft.Extensions.Configuration.UserSecrets: 1.0.0-rc1-final success
Writing changes back to project.json file
All done! The changes were saved to project file.
For more information about UserSecrets please visit: https://docs.asp.net/en/latest/security/app-secrets.html
```

Tests:

The tests are added into separate test file as I found a problem with running nested generators within a single test using current 'test-utility' implementation. I've created modified version of the same Yo method swap as created by @david-driscoll which seems to fix problem, but to be sure I've put all test into separate file for now.

The tests validate 3 different usage scenarios (as shown above):
```
aspnet:UserSecrets
    It does not create any file artefacts when called in directory without project.json
      ✓ there is no project.json created in current directory
    It does not override existing keys in project.json
      ✓ There is a project.json file already created
      ✓ The userSecretId key is not overriden
      ✓ the UserSecrets nuget package version is not changed
    It creates expected keys in project.json
      ✓ There is a project.json file already created
      ✓ The userSecretId key is added
      ✓ The correctly formatted userSecretId value is added
      ✓ the UserSecrets nuget package version is added
```

Thanks!