### PR TITLE
:art: Add subgenerator to create README. Closes #549

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The alphabetic list of available sub generators (_to create files after the proj
 * [aspnet:MvcView](#mvcview)
 * [aspnet:nuget](#nuget)
 * [aspnet:PackageJson](#packagejson)
+* [aspnet:readme](#readme)
 * [aspnet:StartupClass](#startupclass)
 * [aspnet:StyleSheet](#stylesheet)
 * [aspnet:StyleSheetLess](#stylesheetless)
@@ -487,6 +488,20 @@ yo aspnet:PackageJson
 ```
 
 Produces `package.json`
+
+[Return to top](#top)
+
+### README
+
+Creates a new REAMDE.md documentation file in Markdown format
+You can optionally pass `--txt` option to use `.txt` extension.
+Example:
+
+```
+yo aspnet:readme [--txt]
+```
+
+Produces `readme.md`
 
 [Return to top](#top)
 

--- a/readme/USAGE
+++ b/readme/USAGE
@@ -1,0 +1,9 @@
+Description:
+	Creates a new README documentation file in Markdown format
+	You could pass optional --txt option to use .txt extension
+
+Example:
+	yo aspnet:readme [--txt]
+
+	This will create:
+		README.md [README.txt]

--- a/readme/index.js
+++ b/readme/index.js
@@ -1,0 +1,19 @@
+'use strict';
+var util = require('util');
+var ScriptBase = require('../script-base-basic.js');
+
+var Generator = module.exports = function Generator() {
+  ScriptBase.apply(this, arguments);
+};
+
+util.inherits(Generator, ScriptBase);
+
+Generator.prototype.createItem = function() {
+  // support optional .txt extension by --txt option
+  var filename = util.format('README.%s', (this.options.txt) ? 'txt' : 'md');
+  this.generateTemplateFile(
+    'README.md',
+    filename, {
+      namespace: this.namespace()
+  });
+};

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,31 @@
+# <%= namespace %>
+
+TODO: Write <%= namespace %> project description
+
+## Installation
+
+TODO: Describe the installation process
+
+## Usage
+
+TODO: Write usage instructions
+
+## Contributing
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## History
+
+TODO: Write history
+
+## Credits
+
+TODO: Write credits
+
+## License
+
+TODO: Write license

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -125,6 +125,38 @@ describe('Subgenerators without arguments tests', function() {
     util.fileContentCheck(filename, 'Check file content for unstable feed', /https:\/\/myget\.org\/f\/aspnetrc1\/api\/v2/);
   });
 
+  describe('aspnet:readme creates README.md', function() {
+    util.goCreate('readme');
+    var filename = 'README.md';
+    util.fileCheck('should create README.md documentation file', filename);
+    util.fileContentCheck(filename, 'Check file content', /^# MyNamespace$/m);
+  });
+
+  describe('aspnet:readme with --txt option creates README.txt', function() {
+    var arg = '--txt';
+    util.goCreateWithArgs('readme', [arg]);
+    var filename = 'README.txt';
+    util.fileCheck('should create README.txt documentation file', filename);
+    util.fileContentCheck(filename, 'Check file content', /^# MyNamespace$/m);
+  });
+
+  describe('aspnet:readme in cwd of project.json should contain correct project name', function() {
+    var dir = util.makeTempDir();
+    util.goCreateApplication('classlib', 'emptyTest', dir);
+    util.goCreate('readme', path.join(dir, 'emptyTest'));
+    util.fileCheck('should create README.md file', 'README.md');
+    util.fileContentCheck('README.md', 'file content check', /^# emptyTest$/m);
+  });
+
+  describe('aspnet:readme with --txt option in cwd of project.json should contain correct project name', function() {
+    var arg = '--txt';
+    var dir = util.makeTempDir();
+    util.goCreateApplication('classlib', 'emptyTest', dir);
+    util.goCreateWithArgs('readme', [arg], path.join(dir, 'emptyTest'));
+    util.fileCheck('should create README.txt file', 'README.txt');
+    util.fileContentCheck('README.txt', 'file content check', /^# emptyTest$/m);
+  });
+
 });
 
 /*


### PR DESCRIPTION
This commit introduces subgenerator that creates README with
Markdown formatted content and support for project namespace.
The generator supports both .md and .txt filename extensions.
The content of project is based on well known OSS gist:
https://git.io/vuA1A
Example workflow:
- create/scaffold ASP.NET 5 project
- CD into a project
- add README.md to that project: `yo aspnet:readme`
Before this commit only web projects comes with README.md template
based on content from VS: aspnet/Templates.
This commit adds that option to other projects and also allows
users to override default README.md templates that comes with
web projects.

usage:
```
yo aspnet:readme
```
(creates `README.md`)
```
yo aspnet:readme --txt
```
(creates `README.txt`)

Example from generated content:
```md
# WebApplicationBasic

TODO: Write WebApplicationBasic project description

## Installation

TODO: Describe the installation process

## Usage

TODO: Write usage instructions

## Contributing

1. Fork it!
2. Create your feature branch: `git checkout -b my-new-feature`
3. Commit your changes: `git commit -am 'Add some feature'`
4. Push to the branch: `git push origin my-new-feature`
5. Submit a pull request :D

## History

TODO: Write history

## Credits

TODO: Write credits

## License

TODO: Write license
```
Thanks!