### PR TITLE
:arrow_up: Update Nancy template to RC1. Fixes #553

### DIFF
--- a/templates/projects/nancy/Startup.cs
+++ b/templates/projects/nancy/Startup.cs
@@ -9,5 +9,8 @@ namespace <%= namespace %>
         {
             app.UseOwin(x => x.UseNancy());
         }
+
+        // Entry point for the application.
+        public static void Main(string[] args) => Microsoft.AspNet.Hosting.WebApplication.Run<Startup>(args);
     }
 }

--- a/templates/projects/nancy/project.json
+++ b/templates/projects/nancy/project.json
@@ -1,11 +1,15 @@
 {
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
     "tooling": {
-      "defaultNamespace": "<%= namespace %>"
+        "defaultNamespace": "<%= namespace %>"
     },
     "dependencies": {
-        "Microsoft.AspNet.Server.Kestrel": "1.0.0-beta8",
-        "Microsoft.AspNet.Owin": "1.0.0-beta8",
-        "Nancy": "1.3.0"
+        "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
+        "Microsoft.AspNet.Owin": "1.0.0-rc1-final",
+        "Nancy": "1.4.3"
     },
     "commands": {
         "web": "Microsoft.AspNet.Server.Kestrel"


### PR DESCRIPTION
This commit updates Nancy template to support RC1.
- project dependencies update to RC1
- Nancy package update to latest version
- support new hosting model from RC1
- small white-space fixes

This PR passes tests, builds and run succesfully on RC1 installed on OS X.

/cc
@spboyer 
Mind reviewing?

Thanks!