### PR TITLE
:memo: Rename ASP.NET 5 to ASP.NET Core 1.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,9 +39,9 @@ Please start a discussion on the [Home repo issue tracker](https://github.com/as
 
 ## Bugs and feature requests?
 
-### Note about ASP.NET 5 and Visual Studio
+### Note about ASP.NET Core 1.0 and Visual Studio
 
-Do not post issues related to ASP.NET 5  and Visual Studio tooling here. Please log a new issue in the appropriate GitHub repo. Here are some of the most common repos:
+Do not post issues related to ASP.NET Core 1.0 and Visual Studio tooling here. Please log a new issue in the appropriate GitHub repo. Here are some of the most common repos:
 
 * [Visual Studio Templates](https://github.com/aspnet/Templates)
 * [Visual Studio Tooling](https://github.com/aspnet/Tooling)
@@ -49,7 +49,7 @@ Do not post issues related to ASP.NET 5  and Visual Studio tooling here. Please 
 * [EntityFramework](https://github.com/aspnet/EntityFramework)
 * [DNX](https://github.com/aspnet/dnx)
 * [MVC](https://github.com/aspnet/Mvc)
-* [ASP.NET 5 Home](https://github.com/aspnet/Home)
+* [ASP.NET Core 1.0 Home](https://github.com/aspnet/Home)
 
 Or browse the full list of repos in the [aspnet](https://github.com/aspnet/) organization.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Version](https://img.shields.io/npm/v/generator-aspnet.svg)
 ![Downloads per month](https://img.shields.io/npm/dm/generator-aspnet.svg)
 
-Yeoman generator for ASP.NET 5 projects
+Yeoman generator for ASP.NET Core 1.0 projects
 
 [![](https://cloud.githubusercontent.com/assets/14539/10418056/b72ae284-7050-11e5-99db-5a0cda8f0ac1.gif)](https://github.com/OmniSharp/generator-aspnet 'ASP.NET 5 Generator')
 
@@ -18,7 +18,7 @@ Yeoman generator for ASP.NET 5 projects
 
 ## Usage
 
-* `yo aspnet` shows a wizard for generating a new ASP.NET app
+* `yo aspnet` shows a wizard for generating a new ASP.NET Core 1.0 app
 
 * `yo aspnet --grunt` generates `Gruntfile.js` files for **web** templates instead of `gulpfile.js`
 
@@ -39,7 +39,7 @@ Full, template based projects available in generator:
 
 The Empty Application, Console Application, Web Application, Web Application Basic (a.k.a. Web Application No Auth), Web API Application and Class Library are based on the templates introduced with Visual Studio 2015. They are available and maintained in the [ASP.NET Templates project](https://github.com/aspnet/Templates).
 
-> ASP.NET Templates provide project templates which are used in Visual Studio for creating ASP.NET 5 applications.
+> ASP.NET Templates provide project templates which are used in Visual Studio for creating ASP.NET Core 1.0 applications.
 
 The Nancy project is based on framework's "Hello World" template:
 [Nancy Getting Started: Introduction](https://github.com/NancyFx/Nancy/wiki/Introduction)
@@ -67,7 +67,7 @@ The valid project types are:
 
 ## Related yeoman generators
 
-The goal of `generator-aspnet` is to provide an experience consistent with creating new ASP.NET 5 (_DNX_) projects
+The goal of `generator-aspnet` is to provide an experience consistent with creating new ASP.NET Core 1.0 (_DNX_) projects
 and files in Visual Studio 2015.
 
 The list of related generators [can be seen on our Wiki section](https://github.com/OmniSharp/generator-aspnet/wiki#related-yeoman-generators)
@@ -214,7 +214,7 @@ Produces `bower.json` and `.bowerrc`
 
 ### Class
 
-Creates a new ASP.NET 5 Class
+Creates a new ASP.NET Core 1.0 Class
 
 Example:
 
@@ -265,7 +265,7 @@ yo aspnet:Dockerfile
 
 Creates a new `Dockerfile`
 
-Are you curious about Docker, Linux containers and ASP.NET 5 Docker image and all these buzz words?
+Are you curious about Docker, Linux containers and ASP.NET Core 1.0 Docker image and all these buzz words?
 - [Docker image for ASP.NET 5 (Docker Hub)](https://hub.docker.com/r/microsoft/aspnet/)
 - [Running ASP.NET 5 applications in Linux Containers with Docker (MSDN)](http://blogs.msdn.com/b/webdev/archive/2015/01/14/running-asp-net-5-applications-in-linux-containers-with-docker.aspx)
 - [ASP.NET 5 : Continuous Integration with Travis-CI, Tutum, Docker, Webhooks and Azure [Advanced]](http://tattoocoder.com/asp-net-5-continuous-integration-with-travis-ci-tutum-docker-webhooks-and-azure/)
@@ -331,7 +331,7 @@ Produces `filename.html`
 
 ### Interface
 
-Creates a new ASP.NET 5 Interface
+Creates a new ASP.NET Core 1.0 Interface
 
 Example:
 
@@ -429,7 +429,7 @@ Produces `filename.cs`
 
 ### MvcController
 
-Creates a new ASP.NET 5 MvcController class
+Creates a new ASP.NET Core 1.0 MvcController class
 
 Example:
 
@@ -461,7 +461,7 @@ namespace MyNamespace
 
 ### MvcView
 
-Creates a new ASP.NET 5 MvcView page file
+Creates a new ASP.NET Core 1.0 MvcView page file
 
 Example:
 
@@ -668,7 +668,7 @@ Produces `filename.tsx`
 
 ### UserSecrets
 
-Adds UserSecrets information to ASP.NET5 `project.json` file.
+Adds UserSecrets information to ASP.NET Core 1.0 `project.json` file.
 The generator do not update existing keys if found and does
 not create new `project.json` file.
 
@@ -686,7 +686,7 @@ This will add following keys to project.json:
 
 ### WebApiController
 
-Creates a new ASP.NET 5 WebApiController class
+Creates a new ASP.NET Core 1.0 WebApiController class
 
 Example:
 

--- a/UserSecrets/USAGE
+++ b/UserSecrets/USAGE
@@ -1,5 +1,5 @@
 Description:
-  Adds UserSecrets information to ASP.NET5 project.json file
+  Adds UserSecrets information to ASP.NET Core 1.0 project.json file
   The generator do not update existing keys if found and does
   not create new project.json file
 

--- a/UserSecrets/index.js
+++ b/UserSecrets/index.js
@@ -52,7 +52,7 @@ Generator.prototype.createItem = function() {
 
 Generator.prototype._projectPath = null;
 /**
- * Creates unique hash for ASP.NET5 userSecretId key
+ * Creates unique hash for ASP.NET Core 1.0 userSecretId key
  * @return {String} unique hash token
  */
 Generator.prototype._generateUserSecretId = function() {
@@ -74,7 +74,7 @@ Generator.prototype._getProject = function() {
   // no-op if project.json is not found
   if (this._projectPath === null) {
     this.log(red('Cannot find project.json file!'));
-    this.log('You need to invoke this generator from within an ASP.NET 5 project');
+    this.log('You need to invoke this generator from within an ASP.NET Core 1.0 project');
     return null;
   }
   this.log("project.json found: %s", green(this._projectPath));

--- a/app/USAGE
+++ b/app/USAGE
@@ -1,6 +1,6 @@
 Description:
 
-  Creates a basic ASP.NET 5 application
+  Creates a basic ASP.NET Core 1.0 application
 
 Subgenerators:
 

--- a/app/index.js
+++ b/app/index.js
@@ -22,7 +22,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
 
 
   init: function() {
-    this.log(yosay('Welcome to the marvellous ASP.NET 5 generator!'));
+    this.log(yosay('Welcome to the marvellous ASP.NET Core 1.0 generator!'));
     this.templatedata = {};
   },
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "generator-aspnet",
   "version": "0.0.93",
-  "description": "Yeoman generator for ASP.NET 5 apps",
+  "description": "Yeoman generator for ASP.NET Core 1.0 apps",
   "license": "Apache-2.0",
   "main": "app/index.js",
   "repository": "OmniSharp/generator-aspnet",

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -6,7 +6,7 @@ var util = require('./test-utility');
 /*
  * can be imported
  */
-describe('aspnet 5 generator', function() {
+describe('aspnet Core 1.0 generator', function() {
   it('can be imported', function() {
     var app = require('../app');
     yeoman.assert.notEqual(app, undefined);

--- a/test/usersecrets.js
+++ b/test/usersecrets.js
@@ -42,7 +42,7 @@ describe('aspnet:UserSecrets', function() {
   });
 
   /**
-   * We are in directory witout ASP.NET5 project.json
+   * We are in directory witout ASP.NET Core 1.0 project.json
    * We don't want to create any artefacts after running UserSecrets
    * that is: make sure we don't create project.json
    */
@@ -63,7 +63,7 @@ describe('aspnet:UserSecrets', function() {
   });
 
   /**
-   * When we are in directory with ASP.NET5 project.json
+   * When we are in directory with ASP.NET Core 1.0 project.json
    * make sure we are not overriding existing keys - as with web template
    * which already comes with UserSecrets implementation.
    * That is: don't mess with existing project.json
@@ -119,7 +119,7 @@ describe('aspnet:UserSecrets', function() {
   });
 
   /**
-   * When we are in directory with existing ASP.NET5 project and there is
+   * When we are in directory with existing ASP.NET Core 1.0 project and there is
    * no UserSupport added to project make sure that required keys are added
    * and values are at least formatted as expected or have correct values
    */


### PR DESCRIPTION
This commit apply recent framework renaming as announced on MSDN (and
elsewhere):
https://blogs.msdn.microsoft.com/webdev/2016/01/19/asp-net-5-is-dead-int
roducing-asp-net-core-1-0-and-net-core-1-0/
The changes in this commit cover only renaming in original content -
with changes in sources based on aspnet/Templates left for future
update via RC2.
So this means that source code in `templates/projects` directory is not changed.
The rename also was not applied to external content and articles links.
Thanks!