### PR TITLE
Generate package.json with lower case name value

### DIFF
--- a/PackageJson/index.js
+++ b/PackageJson/index.js
@@ -8,6 +8,6 @@ var Generator = module.exports = function Generator() {
 
 util.inherits(Generator, ScriptBase);
 
-Generator.prototype.createItem = function() {
+Generator.prototype.createItem = function () {
   this.generateTemplateFile('package.json', 'package.json', { namespace: this.namespace() });
 };

--- a/templates/package.json
+++ b/templates/package.json
@@ -1,6 +1,6 @@
 {
     "version": "0.0.0",
-    "name": "<%= namespace %>",
+    "name": "<%= namespace.toLowerCase() %>",
     "devDependencies": {
     }
 }

--- a/templates/projects/web/package.json
+++ b/templates/projects/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "<%= namespace %>",
+  "name": "<%= namespace.toLowerCase() %>",
   "version": "0.0.0",
   "devDependencies": {<% if(!grunt){ %>
     "gulp": "^3.9.0",

--- a/templates/projects/webbasic/package.json
+++ b/templates/projects/webbasic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "<%= namespace %>",
+  "name": "<%= namespace.toLowerCase() %>",
   "version": "0.0.0",
   "devDependencies": {<% if(!grunt){ %>
     "gulp": "^3.9.0",

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -19,7 +19,7 @@ describe('Subgenerators without arguments tests', function() {
 
     util.goCreate('PackageJson', path.join(dir, 'emptyTest'));
     util.fileCheck('should create package json file', 'package.json');
-    util.fileContentCheck('package.json', 'file content check', '"name": "emptyTest"');
+    util.fileContentCheck('package.json', 'file content check', '"name": "emptytest"');
   });
 
   describe('aspnet:Gulpfile', function() {


### PR DESCRIPTION
Per the npm `package.json` specs, the file's `name` property value shouldn't contain uppercase letters. See https://github.com/SchemaStore/schemastore/pull/98 for more info and context around this. This particular PR addresses the problem in the "PackageJson" sub-generator and in the 2 web project generators. For example, the "PackageJson" sub-generator will now produce the following:

```json
{
    "version": "0.0.0",
    "name": "mynamespace",
    "devDependencies": {
    }
}
```