### PR TITLE
Added server.urls in project.json. Closes #562

### DIFF
--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -8,4 +8,4 @@ WORKDIR /app
 RUN ["dnu", "restore"]
 
 EXPOSE 5000/tcp
-ENTRYPOINT ["dnx", "-p", "project.json", "web"]
+ENTRYPOINT ["dnx", "-p", "project.json", "Microsoft.AspNet.Server.Kestrel", "--server.urls", "http://0.0.0.0:5000"]


### PR DESCRIPTION
Added `--server.urls` when starting Kestrel to attach to `0.0.0.0` instead of `localhost`.