### PR TITLE
change string from ASP.NET 5 to ASP.NET Core

### DIFF
--- a/templates/projects/empty/wwwroot/README.md
+++ b/templates/projects/empty/wwwroot/README.md
@@ -1,12 +1,12 @@
-# Welcome to ASP.NET 5
+# Welcome to ASP.NET Core
 
 We've made some big updates in this release, so it’s **important** that you spend a few minutes to learn what’s new.
 
-You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
+You've created a new ASP.NET Core project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
 
 ## This application consists of:
 
-*   Sample pages using ASP.NET MVC 6
+*   Sample pages using ASP.NET MVC Core
 *   [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side libraries
 *   Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
 
@@ -22,8 +22,8 @@ You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.c
 
 ## Overview
 
-*   [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
-*   [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
+*   [Conceptual overview of what is ASP.NET Core](http://go.microsoft.com/fwlink/?LinkId=518008)
+*   [Fundamentals of ASP.NET Core such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
 *   [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
 *   [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
 *   [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)

--- a/templates/projects/web/README.md
+++ b/templates/projects/web/README.md
@@ -1,12 +1,12 @@
-# Welcome to ASP.NET 5
+# Welcome to ASP.NET Core
 
 We've made some big updates in this release, so it’s **important** that you spend a few minutes to learn what’s new.
 
-You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
+You've created a new ASP.NET Core project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
 
 ## This application consists of:
 
-*   Sample pages using ASP.NET MVC 6
+*   Sample pages using ASP.NET MVC Core
 *   [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side libraries
 *   Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
 
@@ -22,8 +22,8 @@ You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.c
 
 ## Overview
 
-*   [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
-*   [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
+*   [Conceptual overview of what is ASP.NET Core](http://go.microsoft.com/fwlink/?LinkId=518008)
+*   [Fundamentals of ASP.NET Core such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
 *   [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
 *   [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
 *   [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)

--- a/templates/projects/web/Views/Home/Index.cshtml
+++ b/templates/projects/web/Views/Home/Index.cshtml
@@ -69,7 +69,7 @@
     <div class="col-md-3">
         <h2>Application uses</h2>
         <ul>
-            <li>Sample pages using ASP.NET MVC 6</li>
+            <li>Sample pages using ASP.NET MVC Core</li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkId=518007">Gulp</a> and <a href="http://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
             <li>Theming using <a href="http://go.microsoft.com/fwlink/?LinkID=398939">Bootstrap</a></li>
         </ul>
@@ -89,8 +89,8 @@
     <div class="col-md-3">
         <h2>Overview</h2>
         <ul>
-            <li><a href="http://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET 5</a></li>
-            <li><a href="http://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET 5 such as Startup and middleware.</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET Core</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET Core such as Startup and middleware.</a></li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkId=398602">Working with Data</a></li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkId=398603">Security</a></li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkID=699321">Client side development</a></li>

--- a/templates/projects/webapi/wwwroot/README.md
+++ b/templates/projects/webapi/wwwroot/README.md
@@ -1,12 +1,12 @@
-# Welcome to ASP.NET 5
+# Welcome to ASP.NET Core
 
 We've made some big updates in this release, so it’s **important** that you spend a few minutes to learn what’s new.
 
-You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
+You've created a new ASP.NET Core project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
 
 ## This application consists of:
 
-*   Sample pages using ASP.NET MVC 6
+*   Sample pages using ASP.NET MVC Core
 *   [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side libraries
 *   Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
 
@@ -22,8 +22,8 @@ You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.c
 
 ## Overview
 
-*   [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
-*   [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
+*   [Conceptual overview of what is ASP.NET Core](http://go.microsoft.com/fwlink/?LinkId=518008)
+*   [Fundamentals of ASP.NET Core such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
 *   [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
 *   [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
 *   [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)

--- a/templates/projects/webbasic/README.md
+++ b/templates/projects/webbasic/README.md
@@ -1,12 +1,12 @@
-# Welcome to ASP.NET 5
+# Welcome to ASP.NET Core
 
 We've made some big updates in this release, so it’s **important** that you spend a few minutes to learn what’s new.
 
-You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
+You've created a new ASP.NET Core project. [Learn what's new](http://go.microsoft.com/fwlink/?LinkId=518016)
 
 ## This application consists of:
 
-*   Sample pages using ASP.NET MVC 6
+*   Sample pages using ASP.NET MVC Core
 *   [Gulp](http://go.microsoft.com/fwlink/?LinkId=518007) and [Bower](http://go.microsoft.com/fwlink/?LinkId=518004) for managing client-side libraries
 *   Theming using [Bootstrap](http://go.microsoft.com/fwlink/?LinkID=398939)
 
@@ -22,8 +22,8 @@ You've created a new ASP.NET 5 project. [Learn what's new](http://go.microsoft.c
 
 ## Overview
 
-*   [Conceptual overview of what is ASP.NET 5](http://go.microsoft.com/fwlink/?LinkId=518008)
-*   [Fundamentals of ASP.NET 5 such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
+*   [Conceptual overview of what is ASP.NET Core](http://go.microsoft.com/fwlink/?LinkId=518008)
+*   [Fundamentals of ASP.NET Core such as Startup and middleware.](http://go.microsoft.com/fwlink/?LinkId=699320)
 *   [Working with Data](http://go.microsoft.com/fwlink/?LinkId=398602)
 *   [Security](http://go.microsoft.com/fwlink/?LinkId=398603)
 *   [Client side development](http://go.microsoft.com/fwlink/?LinkID=699321)

--- a/templates/projects/webbasic/Views/Home/Index.cshtml
+++ b/templates/projects/webbasic/Views/Home/Index.cshtml
@@ -69,7 +69,7 @@
     <div class="col-md-3">
         <h2>Application uses</h2>
         <ul>
-            <li>Sample pages using ASP.NET MVC 6</li>
+            <li>Sample pages using ASP.NET MVC Core</li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkId=518007">Gulp</a> and <a href="http://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
             <li>Theming using <a href="http://go.microsoft.com/fwlink/?LinkID=398939">Bootstrap</a></li>
         </ul>
@@ -89,8 +89,8 @@
     <div class="col-md-3">
         <h2>Overview</h2>
         <ul>
-            <li><a href="http://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET 5</a></li>
-            <li><a href="http://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET 5 such as Startup and middleware.</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET Core</a></li>
+            <li><a href="http://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET Core such as Startup and middleware.</a></li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkId=398602">Working with Data</a></li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkId=398603">Security</a></li>
             <li><a href="http://go.microsoft.com/fwlink/?LinkID=699321">Client side development</a></li>


### PR DESCRIPTION
Not tied to any issue.

Summary of the changes in this PR:
 - Changed texts from using the ASP.NET 5 name to use the ASP.NET Core
 - Changed text in README
 - Changed texts used in `yo` interface
 - Changed texts in generated UI

/cc
@OmniSharp/generator-aspnet-team-push

