### PR TITLE
:bug: Add fallback class tests for Semantic UI. Fixes #574

### DIFF
--- a/templates/overrides/semantic/web/Views/Shared/_Layout.cshtml
+++ b/templates/overrides/semantic/web/Views/Shared/_Layout.cshtml
@@ -13,9 +13,8 @@
     </environment>
     <environment names="Staging,Production">
         <link rel="stylesheet" href="https://oss.maxcdn.com/semantic-ui/2.1.8/semantic.min.css"
-              asp-fallback-ref="~/lib/semantic/dist/semantic.min.css"
-              asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute" />
-
+              asp-fallback-href="~/lib/semantic/dist/semantic.min.css"
+              asp-fallback-test-class="i icon" asp-fallback-test-property="fontFamily" asp-fallback-test-value="Icons" />
         <link rel="stylesheet" href="~/css/site.min.css" asp-append-version="true" />
     </environment>
 </head>

--- a/templates/overrides/semantic/webbasic/Views/Shared/_Layout.cshtml
+++ b/templates/overrides/semantic/webbasic/Views/Shared/_Layout.cshtml
@@ -13,9 +13,8 @@
     </environment>
     <environment names="Staging,Production">
         <link rel="stylesheet" href="https://oss.maxcdn.com/semantic-ui/2.1.8/semantic.min.css"
-              asp-fallback-ref="~/lib/semantic/dist/semantic.min.css"
-              asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute" />
-
+              asp-fallback-href="~/lib/semantic/dist/semantic.min.css"
+              asp-fallback-test-class="i icon" asp-fallback-test-property="fontFamily" asp-fallback-test-value="Icons" />
         <link rel="stylesheet" href="~/css/site.min.css" asp-append-version="true" />
     </environment>
 </head>


### PR DESCRIPTION
This commit adds fallback tests for Semantic UI CSS link tag.
The check is based on non-obtrusive class. After this change
a local fallback url is correctly used at runtime.

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push