### PR TITLE
Update Semantic-UI CSS fallback class

### DIFF
--- a/templates/overrides/semantic/web/Views/Shared/_Layout.cshtml
+++ b/templates/overrides/semantic/web/Views/Shared/_Layout.cshtml
@@ -14,7 +14,7 @@
     <environment names="Staging,Production">
         <link rel="stylesheet" href="https://oss.maxcdn.com/semantic-ui/2.1.8/semantic.min.css"
               asp-fallback-href="~/lib/semantic/dist/semantic.min.css"
-              asp-fallback-test-class="i icon" asp-fallback-test-property="fontFamily" asp-fallback-test-value="Icons" />
+              asp-fallback-test-class="ui button" asp-fallback-test-property="cursor" asp-fallback-test-value="pointer" />
         <link rel="stylesheet" href="~/css/site.min.css" asp-append-version="true" />
     </environment>
 </head>

--- a/templates/overrides/semantic/webbasic/Views/Shared/_Layout.cshtml
+++ b/templates/overrides/semantic/webbasic/Views/Shared/_Layout.cshtml
@@ -14,7 +14,7 @@
     <environment names="Staging,Production">
         <link rel="stylesheet" href="https://oss.maxcdn.com/semantic-ui/2.1.8/semantic.min.css"
               asp-fallback-href="~/lib/semantic/dist/semantic.min.css"
-              asp-fallback-test-class="i icon" asp-fallback-test-property="fontFamily" asp-fallback-test-value="Icons" />
+              asp-fallback-test-class="ui button" asp-fallback-test-property="cursor" asp-fallback-test-value="pointer" />
         <link rel="stylesheet" href="~/css/site.min.css" asp-append-version="true" />
     </environment>
 </head>


### PR DESCRIPTION
This is hot-fix PR.

This commit updates fallback class used for Semantic-UI CSS
added with: 1e7cd8e6
The class used by this commit and tested property seems to
work much better on tests

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push