### PR TITLE
:memo: Improve issue template for NPM 3

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -27,6 +27,11 @@ yo --version
 
 
 #### Generator version
+NPM 3.*:
+```
+npm list -g generator-aspnet
+```
+NPM 2.*:
 ```
 npm ls generator-aspnet -ls=0 --long
 ```


### PR DESCRIPTION
The NPM 3 has different syntax to get generator-aspnet
version installed on user machine. The current hint
is not returning result under NPM 3 - hence this change.

The current hint returns no results:
```
npm ls generator-aspnet             
/Users/piotrblazejewicz
└── (empty)

npm ERR! code 1
```
New syntax for NPM 3 returns sth like:
```
npm list -g generator-aspnet
/usr/local/lib
└── generator-aspnet@0.0.93  -> /Users/piotrblazejewicz/git/generator-aspnet
```
Thanks!

/cc
@OmniSharp/generator-aspnet-team-push 