### PR TITLE
Feature/linters formatting

### DIFF
--- a/test/test-core.js
+++ b/test/test-core.js
@@ -492,51 +492,51 @@ describe('aspnet - Web Application (Semantic UI)', function() {
       util.filesCheck(files[i]);
     }
   });
-  
-  
+
+
   describe('Checking file content for overrides', function(){
-    
+
     it('_Layout.cshtml contains menulink tags', function(){
         assert.fileContent('webTest/Views/Shared/_Layout.cshtml', "menulink");
-    })
-    
+    });
+
     it('_ViewImports.cshtml contains TagHelper', function(){
         assert.fileContent('webTest/Views/_ViewImports.cshtml', '*, webTest');
-    })
-      
+    });
+
     it('_ValidationScriptsPartial.cshtml contains reference to semantic.validation.js', function(){
         assert.fileContent('webTest/Views/Shared/_ValidationScriptsPartial.cshtml', 'semantic.validation.js');
-    })
-    
+    });
+
     it('site.css is overridden', function(){
         assert.fileContent('webTest/wwwroot/css/site.css', '.masthead');
-    })
-    
+    });
+
     it('site.js is overridden', function(){
         assert.fileContent('webTest/wwwroot/js/site.js', '.sidebar(');
-    })
-    
+    });
+
     //We wont explicitly check every single file in every directory, one file per directory should suffice
-    
+
     it('Views/Account/ConfirmEmail.cshtml contains Semantic UI markup', function(){
         assert.fileContent('webTest/Views/Account/ConfirmEmail.cshtml', 'ui header');
-    })
-    
+    });
+
     it('Views/Home/About.cshtml contains Semantic UI markup', function(){
         assert.fileContent('webTest/Views/Home/About.cshtml', 'ui container');
-    })
-    
+    });
+
     it('Views/Manage/AddPhoneNumber.cshtml contains Semantic UI markup', function(){
         assert.fileContent('webTest/Views/Manage/AddPhoneNumber.cshtml', 'ui header');
-    })
-    
+    });
+
     it('Views/Shared/Error.cshtml contains Semantic UI markup', function(){
         assert.fileContent('webTest/Views/Shared/Error.cshtml', 'ui header');
-    })
-    
+    });
+
     it('bower.json contains semantic references', function(){
         assert.fileContent('webTest/bower.json', 'semantic');
-    })
+    });
   });
 
 });
@@ -762,38 +762,38 @@ describe('aspnet - Web Application Basic (Semantic UI)', function() {
       util.filesCheck(files[i]);
     }
   });
-  
+
   describe('Checking file content for overrides', function(){
-    
+
     it('_Layout.cshtml contains menulink tags', function(){
         assert.fileContent('webTest/Views/Shared/_Layout.cshtml', "menulink");
-    })
-    
+    });
+
     it('_ViewImports.cshtml contains TagHelper', function(){
         assert.fileContent('webTest/Views/_ViewImports.cshtml', '*, webTest');
-    })
-    
+    });
+
     it('site.css is overridden', function(){
         assert.fileContent('webTest/wwwroot/css/site.css', '.masthead');
-    })
-    
+    });
+
     it('site.js is overridden', function(){
         assert.fileContent('webTest/wwwroot/js/site.js', '.sidebar(');
-    })
-    
+    });
+
     //We wont explicitly check every single file in every directory, one file per directory should suffice
-    
+
     it('Views/Home/About.cshtml contains Semantic UI markup', function(){
         assert.fileContent('webTest/Views/Home/About.cshtml', 'ui container');
-    })
-    
+    });
+
     it('Views/Shared/Error.cshtml contains Semantic UI markup', function(){
         assert.fileContent('webTest/Views/Shared/Error.cshtml', 'ui header');
-    })
-    
+    });
+
     it('bower.json contains semantic references', function(){
         assert.fileContent('webTest/bower.json', 'semantic');
-    })
+    });
   });
 
 });
@@ -877,7 +877,7 @@ describe('command line options', function() {
     var app = require('../app');
     app.prototype.log = function() {}; //stub
     app.prototype.type = 'webbasic';
-    app.prototype.applicationName = 'myWebApp'
+    app.prototype.applicationName = 'myWebApp';
     app.prototype.ui = 'bootstrap';
 
     app.prototype._checkProjectType();
@@ -891,7 +891,7 @@ describe('command line options', function() {
     var app = require('../app');
     app.prototype.log = function() {}; //stub
     app.prototype.type = 'not-a-real-project-type';
-    app.prototype.applicationName = 'myWebApp'
+    app.prototype.applicationName = 'myWebApp';
 
     app.prototype._checkProjectType();
 

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -344,7 +344,7 @@ describe('aspnet - Web Application (Semantic UI)', function() {
     it('Controllers directory created', function() {
       assert.file('webTest/Controllers');
     });
-    
+
     it('Migrations directory created', function() {
       assert.file('webTest/Migrations');
     });
@@ -356,7 +356,7 @@ describe('aspnet - Web Application (Semantic UI)', function() {
     it('Services directory created', function() {
       assert.file('webTest/Services');
     });
-    
+
     it('TagHelpers directory created', function() {
       assert.file('webTest/TagHelpers');
     });
@@ -404,8 +404,6 @@ describe('aspnet - Web Application (Semantic UI)', function() {
     it('wwwroot/js directory created', function() {
       assert.file('webTest/wwwroot/js');
     });
-    
-    
 
   });
 
@@ -494,48 +492,48 @@ describe('aspnet - Web Application (Semantic UI)', function() {
   });
 
 
-  describe('Checking file content for overrides', function(){
+  describe('Checking file content for overrides', function() {
 
-    it('_Layout.cshtml contains menulink tags', function(){
-        assert.fileContent('webTest/Views/Shared/_Layout.cshtml', "menulink");
+    it('_Layout.cshtml contains menulink tags', function() {
+      assert.fileContent('webTest/Views/Shared/_Layout.cshtml', "menulink");
     });
 
-    it('_ViewImports.cshtml contains TagHelper', function(){
-        assert.fileContent('webTest/Views/_ViewImports.cshtml', '*, webTest');
+    it('_ViewImports.cshtml contains TagHelper', function() {
+      assert.fileContent('webTest/Views/_ViewImports.cshtml', '*, webTest');
     });
 
-    it('_ValidationScriptsPartial.cshtml contains reference to semantic.validation.js', function(){
-        assert.fileContent('webTest/Views/Shared/_ValidationScriptsPartial.cshtml', 'semantic.validation.js');
+    it('_ValidationScriptsPartial.cshtml contains reference to semantic.validation.js', function() {
+      assert.fileContent('webTest/Views/Shared/_ValidationScriptsPartial.cshtml', 'semantic.validation.js');
     });
 
-    it('site.css is overridden', function(){
-        assert.fileContent('webTest/wwwroot/css/site.css', '.masthead');
+    it('site.css is overridden', function() {
+      assert.fileContent('webTest/wwwroot/css/site.css', '.masthead');
     });
 
-    it('site.js is overridden', function(){
-        assert.fileContent('webTest/wwwroot/js/site.js', '.sidebar(');
+    it('site.js is overridden', function() {
+      assert.fileContent('webTest/wwwroot/js/site.js', '.sidebar(');
     });
 
     //We wont explicitly check every single file in every directory, one file per directory should suffice
 
-    it('Views/Account/ConfirmEmail.cshtml contains Semantic UI markup', function(){
-        assert.fileContent('webTest/Views/Account/ConfirmEmail.cshtml', 'ui header');
+    it('Views/Account/ConfirmEmail.cshtml contains Semantic UI markup', function() {
+      assert.fileContent('webTest/Views/Account/ConfirmEmail.cshtml', 'ui header');
     });
 
-    it('Views/Home/About.cshtml contains Semantic UI markup', function(){
-        assert.fileContent('webTest/Views/Home/About.cshtml', 'ui container');
+    it('Views/Home/About.cshtml contains Semantic UI markup', function() {
+      assert.fileContent('webTest/Views/Home/About.cshtml', 'ui container');
     });
 
-    it('Views/Manage/AddPhoneNumber.cshtml contains Semantic UI markup', function(){
-        assert.fileContent('webTest/Views/Manage/AddPhoneNumber.cshtml', 'ui header');
+    it('Views/Manage/AddPhoneNumber.cshtml contains Semantic UI markup', function() {
+      assert.fileContent('webTest/Views/Manage/AddPhoneNumber.cshtml', 'ui header');
     });
 
-    it('Views/Shared/Error.cshtml contains Semantic UI markup', function(){
-        assert.fileContent('webTest/Views/Shared/Error.cshtml', 'ui header');
+    it('Views/Shared/Error.cshtml contains Semantic UI markup', function() {
+      assert.fileContent('webTest/Views/Shared/Error.cshtml', 'ui header');
     });
 
-    it('bower.json contains semantic references', function(){
-        assert.fileContent('webTest/bower.json', 'semantic');
+    it('bower.json contains semantic references', function() {
+      assert.fileContent('webTest/bower.json', 'semantic');
     });
   });
 
@@ -689,7 +687,7 @@ describe('aspnet - Web Application Basic (Semantic UI)', function() {
     it('Controllers directory created', function() {
       assert.file('webTest/Controllers');
     });
-    
+
     it('TagHelpers directory created', function() {
       assert.file('webTest/TagHelpers');
     });
@@ -763,36 +761,36 @@ describe('aspnet - Web Application Basic (Semantic UI)', function() {
     }
   });
 
-  describe('Checking file content for overrides', function(){
+  describe('Checking file content for overrides', function() {
 
-    it('_Layout.cshtml contains menulink tags', function(){
-        assert.fileContent('webTest/Views/Shared/_Layout.cshtml', "menulink");
+    it('_Layout.cshtml contains menulink tags', function() {
+      assert.fileContent('webTest/Views/Shared/_Layout.cshtml', "menulink");
     });
 
-    it('_ViewImports.cshtml contains TagHelper', function(){
-        assert.fileContent('webTest/Views/_ViewImports.cshtml', '*, webTest');
+    it('_ViewImports.cshtml contains TagHelper', function() {
+      assert.fileContent('webTest/Views/_ViewImports.cshtml', '*, webTest');
     });
 
-    it('site.css is overridden', function(){
-        assert.fileContent('webTest/wwwroot/css/site.css', '.masthead');
+    it('site.css is overridden', function() {
+      assert.fileContent('webTest/wwwroot/css/site.css', '.masthead');
     });
 
-    it('site.js is overridden', function(){
-        assert.fileContent('webTest/wwwroot/js/site.js', '.sidebar(');
+    it('site.js is overridden', function() {
+      assert.fileContent('webTest/wwwroot/js/site.js', '.sidebar(');
     });
 
     //We wont explicitly check every single file in every directory, one file per directory should suffice
 
-    it('Views/Home/About.cshtml contains Semantic UI markup', function(){
-        assert.fileContent('webTest/Views/Home/About.cshtml', 'ui container');
+    it('Views/Home/About.cshtml contains Semantic UI markup', function() {
+      assert.fileContent('webTest/Views/Home/About.cshtml', 'ui container');
     });
 
-    it('Views/Shared/Error.cshtml contains Semantic UI markup', function(){
-        assert.fileContent('webTest/Views/Shared/Error.cshtml', 'ui header');
+    it('Views/Shared/Error.cshtml contains Semantic UI markup', function() {
+      assert.fileContent('webTest/Views/Shared/Error.cshtml', 'ui header');
     });
 
-    it('bower.json contains semantic references', function(){
-        assert.fileContent('webTest/bower.json', 'semantic');
+    it('bower.json contains semantic references', function() {
+      assert.fileContent('webTest/bower.json', 'semantic');
     });
   });
 

--- a/test/test-utility.js
+++ b/test/test-utility.js
@@ -130,7 +130,6 @@ var util = (function() {
 
   function filesCheck(file) {
 
-
     it(file + ' created.', function() {
       assert.file(file);
     });


### PR DESCRIPTION
This commit unifies white-space in recently updated test files and adds missing semicolons to avoid linters warnings.
I'd like to have this fixed before starting to work on yeoman-generator update to 0.22 - which will require code changes (a simple update via NPM package.json update breaks tests and generated content).

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push
