### PR TITLE
:art: Update NPM package keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,13 @@
   "keywords": [
     "yeoman-generator",
     "ASP.NET",
+    "ASP.NET Core",
     "aspnet",
+    "aspnet core",
     "ASP",
+    ".net",
     "net",
-    "vNext",
+    "core",
     "dnx"
   ],
   "dependencies": {


### PR DESCRIPTION
- ASP.NET Core introduction
- vNext is phased out

The .NET Core is not yet widely present on NPM.
Hence this commit to move generator up in the results

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push

