### PR TITLE
:bug: Use NPM default execution path for Mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "mocha": "^2.3.3"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha ./test"
+    "test": "mocha"
   }
 }


### PR DESCRIPTION
This commit fixes an error that is ostensible only
on Windows OS. Instead of using explicit paths that
fails to resolve on Windows lets use built-in NPM
path resolution that should pick a Mocha module from
repo and only if not found use global one:
https://github.com/npm/npm/issues/2576#issuecomment-6607826

/cc
@OmniSharp/generator-aspnet-team-push