### PR TITLE
:art: Add Program.cs generator for RC2. Closes #616

### DIFF
--- a/Program/USAGE
+++ b/Program/USAGE
@@ -1,0 +1,8 @@
+Description:
+	Creates a new Program.cs file
+
+Example:
+	yo aspnet:Program
+
+	This will create:
+		Program.cs

--- a/Program/index.js
+++ b/Program/index.js
@@ -1,0 +1,13 @@
+'use strict';
+var util = require('util');
+var ScriptBase = require('../script-base-basic.js');
+
+var Generator = module.exports = function Generator() {
+  ScriptBase.apply(this, arguments);
+};
+
+util.inherits(Generator, ScriptBase);
+
+Generator.prototype.createItem = function () {
+  this.generateTemplateFile('Program.cs', 'Program.cs', { namespace: this.namespace() });
+};

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The alphabetic list of available sub generators (_to create files after the proj
 * [aspnet:MvcView](#mvcview)
 * [aspnet:nuget](#nuget)
 * [aspnet:PackageJson](#packagejson)
+* [aspnet:Program](#program)
 * [aspnet:readme](#readme)
 * [aspnet:StartupClass](#startupclass)
 * [aspnet:StyleSheet](#stylesheet)
@@ -521,6 +522,20 @@ yo aspnet:PackageJson
 ```
 
 Produces `package.json`
+
+[Return to top](#top)
+
+### Program
+
+Creates a new `Program.cs` file
+
+Example:
+
+```
+yo aspnet:Program
+```
+
+Produces `Program.cs`
 
 [Return to top](#top)
 

--- a/app/USAGE
+++ b/app/USAGE
@@ -28,6 +28,7 @@ Subgenerators:
   yo aspnet:MvcView [options] <name>
   yo aspnet:nuget [options]
   yo aspnet:PackageJson [options]
+  yo aspnet:Program [options]
   yo aspnet:StartupClass [options]
   yo aspnet:StyleSheet [options] <name>
   yo aspnet:StyleSheetLess [options] <name>

--- a/templates/Program.cs
+++ b/templates/Program.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace <%= namespace %>
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -22,6 +22,20 @@ describe('Subgenerators without arguments tests', function() {
     util.fileContentCheck('package.json', 'file content check', '"name": "emptywebtest"');
   });
 
+  describe('aspnet:Program', function() {
+    util.goCreate('Program');
+    util.fileCheck('should create Program.cs file', 'Program.cs');
+  });
+
+  describe('aspnet:Program in cwd of project.json', function() {
+    var dir = util.makeTempDir();
+    // the Nancy project does not contain Program.cs
+    util.goCreateApplication('nancy', 'emptyTest', dir);
+    util.goCreate('Program', path.join(dir, 'emptyTest'));
+    util.fileCheck('should create Program.cs file', 'Program.cs');
+    util.fileContentCheck('Program.cs', 'file content check', /^namespace emptyTest$/m);
+  });
+
   describe('aspnet:Gulpfile', function() {
     util.goCreate('Gulpfile');
     util.fileCheck('should create gulp file', 'gulpfile.js');


### PR DESCRIPTION
This commit adds Program.cs entry point generator
compatible with RC2 onwards.

The content of Program.cs is based on
content generated with `dotnet new`.
This commits updates tests and usage
information to cover that addition.

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push