### PR TITLE
:arrow_up: Update Nuget config generator for RC2. Closes #617

### DIFF
--- a/templates/_nuget.config
+++ b/templates/_nuget.config
@@ -4,6 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear /> line below -->
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" /><% if(unstable){ %>
-    <add key="aspnetrelease" value="https://myget.org/f/aspnetrc1/api/v2" /><% } %>
+    <add key="aspnetrelease" value="https://www.myget.org/F/aspnetrelease/api/v3/index.json" /><% } %>
   </packageSources>
 </configuration>

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -113,7 +113,7 @@ describe('Subgenerators without arguments tests', function() {
     var filename = 'NuGet.config';
     util.fileCheck('should create NuGet configuration file', filename);
     util.fileContentCheck(filename, 'Check file content', /api\.nuget\.org/);
-    util.noFileContentCheck(filename, 'Check file content for no unstable feed', /https:\/\/myget\.org\/f\/aspnetrc1\/api\/v2/);
+    util.noFileContentCheck(filename, 'Check file content for no unstable feed', /https:\/\/www\.myget\.org\/F\/aspnetrelease\/api\/v3/);
   });
 
   // unstable feed should be found in generated file
@@ -122,7 +122,7 @@ describe('Subgenerators without arguments tests', function() {
     var filename = 'NuGet.config';
     util.goCreateWithArgs('nuget', [arg]);
     util.fileCheck('should create ' + filename + ' file with unstable feed', filename);
-    util.fileContentCheck(filename, 'Check file content for unstable feed', /https:\/\/myget\.org\/f\/aspnetrc1\/api\/v2/);
+    util.fileContentCheck(filename, 'Check file content for unstable feed', /https:\/\/www\.myget\.org\/F\/aspnetrelease\/api\/v3/);
   });
 
   describe('aspnet:readme creates README.md', function() {


### PR DESCRIPTION
This commit updates feed links used in prelease version
to match one that works with dotnet.
The tests checks are also updated to reflect this change.

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push

The config was tested with Empty web template:
```
yo aspnet:nuget --unstable
You called the aspnet subgenerator with the arg _nuget.config
NuGet.config created.
   create NuGet.config
➜  EmptyWebApplication dotnet restore
log  : Restoring packages for /Users/piotrblazejewicz/development/EmptyWebApplication/project.json...
info :   GET https://api.nuget.org/v3-flatcontainer/libuv/index.json
info :   CACHE https://www.myget.org/F/aspnetrelease/api/v3/flatcontainer/libuv/index.json
info :   CACHE https://api.nuget.org/v3-flatcontainer/system.appcontext/index.json
info :   CACHE https://www.myget.org/F/aspnetrelease/api/v3/flatcontainer/system.appcontext/index.json
info :   CACHE https://api.nuget.org/v3-flatcontainer/system.collections/index.json
...
log  : Restore completed in 2979ms.

NuGet Config files used:
    /Users/piotrblazejewicz/development/EmptyWebApplication/NuGet.Config
    /Users/piotrblazejewicz/.nuget/NuGet/NuGet.Config

Feeds used:
    https://api.nuget.org/v3/index.json
    https://www.myget.org/F/aspnetrelease/api/v3/index.json
➜  EmptyWebApplication dotnet build
Compiling EmptyWebApplication for .NETCoreApp,Version=v1.0

Compilation succeeded.
    0 Warning(s)
    0 Error(s)

Time elapsed 00:00:04.9473123
```