### PR TITLE
:arrow_up: Update TagHelper generator for RC2. Closes #619

### DIFF
--- a/templates/TagHelper.cs
+++ b/templates/TagHelper.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNet.Razor.Runtime.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace <%= namespace %>
 {


### PR DESCRIPTION
This commit introduces simple change to make TagHelper
generator compatible with RC2 release.
The changes includes changes introduced in aspnet/Mvc:
aspnet/Announcements#89
aspnet/Announcements#144

Thanks!

The output was tested by scaffolding custom tag helpers used in basic web template.

/cc
@OmniSharp/generator-aspnet-team-push
