### PR TITLE
Handle child dirs in aspnet:Class #632

### DIFF
--- a/Class/index.js
+++ b/Class/index.js
@@ -14,7 +14,7 @@ NamedGenerator.prototype.createNamedItem = function() {
   //   namespaceSuffix: foo.bar.baz
   //   classname: wibble
   var namespace = this.namespace();
-  var pathSegments = this.classNameWithoutExtension(extension).split('\\');
+  var pathSegments = this.classNameWithoutExtension(extension).replace(/\//g, '\\').split('\\');
   var namespaceSuffix = pathSegments.slice(0, -1).join('.');
   if (namespaceSuffix !== '') {
     namespace += "." + namespaceSuffix;

--- a/Class/index.js
+++ b/Class/index.js
@@ -10,11 +10,21 @@ util.inherits(NamedGenerator, ScriptBase);
 
 NamedGenerator.prototype.createNamedItem = function() {
   var extension = '.cs';
+  // foo\bar\baz\wibble.cs becomes
+  //   namespaceSuffix: foo.bar.baz
+  //   classname: wibble
+  var namespace = this.namespace();
+  var pathSegments = this.classNameWithoutExtension(extension).split('\\');
+  var namespaceSuffix = pathSegments.slice(0, -1).join('.');
+  if (namespaceSuffix !== '') {
+    namespace += "." + namespaceSuffix;
+  }
+  var classname = pathSegments[pathSegments.length-1];
   this.generateTemplateFile(
     'class.cs',
     extension, {
-      namespace: this.namespace(),
-      classname: this.classNameWithoutExtension(extension)
+      namespace: namespace,
+      classname: classname
     }
   );
 };

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -338,6 +338,22 @@ describe('Subgenerators with named arguments tests', function() {
     util.fileContentCheck(filename, 'Check file content', /[ ]*public[ ]*class[ ]*MyClass/);
     util.fileContentCheck(filename, 'Check file content', 'namespace emptyTest');
   });
+  
+  
+  describe('aspnet:Class in child dir of project.json', function() {
+    var dir = util.makeTempDir();
+
+    util.goCreateApplication('classlib', 'emptyTest', dir);
+
+    var arg = 'foo\\bar\\MyClass';
+    var filename = 'foo\\bar\\MyClass.cs';
+    console.log(arg, dir);
+
+    util.goCreateWithArgs('Class', [arg], path.join(dir, 'emptyTest'));
+    util.fileCheck('should create ' + filename + ' file', filename);
+    util.fileContentCheck(filename, 'Check file content', /[ ]*public[ ]*class[ ]*MyClass/);
+    util.fileContentCheck(filename, 'Check file content', 'namespace emptyTest.foo.bar');
+  });
 
   describe('aspnet:CoffeeScript without extension', function() {
     var arg = 'file';

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -340,12 +340,27 @@ describe('Subgenerators with named arguments tests', function() {
   });
   
   
-  describe('aspnet:Class in child dir of project.json', function() {
+  describe('aspnet:Class in child dir of project.json (backslash)', function() {
     var dir = util.makeTempDir();
 
     util.goCreateApplication('classlib', 'emptyTest', dir);
 
     var arg = 'foo\\bar\\MyClass';
+    var filename = 'foo\\bar\\MyClass.cs';
+    console.log(arg, dir);
+
+    util.goCreateWithArgs('Class', [arg], path.join(dir, 'emptyTest'));
+    util.fileCheck('should create ' + filename + ' file', filename);
+    util.fileContentCheck(filename, 'Check file content', /[ ]*public[ ]*class[ ]*MyClass/);
+    util.fileContentCheck(filename, 'Check file content', 'namespace emptyTest.foo.bar');
+  });
+
+  describe('aspnet:Class in child dir of project.json (forwardslash)', function() {
+    var dir = util.makeTempDir();
+
+    util.goCreateApplication('classlib', 'emptyTest', dir);
+
+    var arg = 'foo/bar/MyClass';
     var filename = 'foo\\bar\\MyClass.cs';
     console.log(arg, dir);
 


### PR DESCRIPTION
Fixes #632.

Summary of the changes in this PR:
 - When templating using aspnet:class subgenerator
   - Use last part of path segment as the classname
   - Use the other parts of the path as additional parts of the namespace

Thanks!
Stuart

/cc
@OmniSharp/generator-aspnet-team-push

