### PR TITLE
Fix SQLite connection string

### DIFF
--- a/templates/projects/web/Startup.cs
+++ b/templates/projects/web/Startup.cs
@@ -36,7 +36,7 @@ namespace <%= namespace %>
 
             builder.AddEnvironmentVariables();
             Configuration = builder.Build();
-            Configuration["Data:DefaultConnection:ConnectionString"] = $@"Data Source={env.ContentRootPath}/<%= namespace %>.db";
+            Configuration["ConnectionStrings:SQLite"] = $@"Data Source={env.ContentRootPath}/<%= namespace %>.db";
         }
 
         public IConfigurationRoot Configuration { get; }
@@ -46,7 +46,7 @@ namespace <%= namespace %>
         {
             // Add framework services.
             services.AddDbContext<ApplicationDbContext>(options =>
-                options.UseSqlite(Configuration.GetConnectionString("Data:DefaultConnection:ConnectionString")));
+                options.UseSqlite(Configuration.GetConnectionString("SQLite")));
 
             services.AddIdentity<ApplicationUser, IdentityRole>()
                 .AddEntityFrameworkStores<ApplicationDbContext>()


### PR DESCRIPTION
The RC2 uses new convention for Configuration
access of connection strings. This commit
adopts that convention to construct and later
read SQLite configuration

Thanks!