### PR TITLE
:bug: Fix invalid namespace in web template

### DIFF
--- a/templates/overrides/semantic/web/Views/Shared/_Layout.cshtml
+++ b/templates/overrides/semantic/web/Views/Shared/_Layout.cshtml
@@ -1,5 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Identity
-@using WebSemantic.Models
+@using <%= namespace %>.Models
 @inject SignInManager<ApplicationUser> SignInManager
 @inject UserManager<ApplicationUser> UserManager
 


### PR DESCRIPTION
Semantic UI version shipped with hardcoded namespace.
This commit fixes this