### PR TITLE
Revert "Rename build options in configuration (#671)"

### DIFF
--- a/templates/projects/consoleapp/project.json
+++ b/templates/projects/consoleapp/project.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0-*",
-  "buildOptions": {
+  "compilationOptions": {
     "emitEntryPoint": true
   },
 

--- a/templates/projects/emptyweb/project.json
+++ b/templates/projects/emptyweb/project.json
@@ -25,7 +25,7 @@
     }
   },
 
-  "buildOptions": {
+  "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },

--- a/templates/projects/nancy/project.json
+++ b/templates/projects/nancy/project.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.0-*",
-    "buildOptions": {
+    "compilationOptions": {
         "emitEntryPoint": true
     },
     "tooling": {

--- a/templates/projects/web/project.json
+++ b/templates/projects/web/project.json
@@ -74,7 +74,7 @@
     }
   },
 
-  "buildOptions": {
+  "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },

--- a/templates/projects/webapi/project.json
+++ b/templates/projects/webapi/project.json
@@ -32,7 +32,7 @@
     }
   },
 
-  "buildOptions": {
+  "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },

--- a/templates/projects/webbasic/project.json
+++ b/templates/projects/webbasic/project.json
@@ -41,7 +41,7 @@
     }
   },
 
-  "buildOptions": {
+  "compilationOptions": {
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },


### PR DESCRIPTION
This reverts commit 917740f3972dfba35d44646a12334b385fb90949.
The builds are failing under .NET Command Line Tools (1.0.0-rc2-002485)
starting from this commit.
The commit was found using git bisect tool:

917740f3972dfba35d44646a12334b385fb90949 is the first bad commit
commit 917740f3972dfba35d44646a12334b385fb90949
Author: Peter Blazejewicz <peterblazejewicz@users.noreply.github.com>
Date:   Fri May 6 22:19:05 2016 +0200

    Rename build options in configuration (#671)

    See aspnet/Templates#536

:040000 040000 1dcdfa62565e51d87aafd32b5b279df6b87570b0
db3df7d2f0358c095ab053c4d3be0f8c1749c8db M      templates

Thanks!