### PR TITLE
Output name field in Bower config in lowercase. Closes #680

### DIFF
--- a/templates/overrides/semantic/web/bower.json
+++ b/templates/overrides/semantic/web/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "<%= namespace %>",
+  "name": "<%= namespace.toLowerCase() %>",
   "private": true,
   "dependencies": {
     "jquery": "2.2.0",

--- a/templates/overrides/semantic/webbasic/bower.json
+++ b/templates/overrides/semantic/webbasic/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "<%= namespace %>",
+  "name": "<%= namespace.toLowerCase() %>",
   "private": true,
   "dependencies": {
     "jquery": "2.2.0",

--- a/templates/projects/web/bower.json
+++ b/templates/projects/web/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "<%= namespace %>",
+  "name": "<%= namespace.toLowerCase() %>",
   "private": true,
   "dependencies": {
     "bootstrap": "3.3.6",

--- a/templates/projects/webbasic/bower.json
+++ b/templates/projects/webbasic/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "<%= namespace %>",
+  "name": "<%= namespace.toLowerCase() %>",
   "private": true,
   "dependencies": {
     "bootstrap": "3.3.6",

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -331,6 +331,10 @@ describe('aspnet - Web Application (Bootstrap)', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+
+    it('bower.json name field is lower case', function() {
+      assert.fileContent('webTest/bower.json', /"name": "webtest"/);
+    });
   });
 
 });
@@ -497,6 +501,10 @@ describe('aspnet - Web Application (Semantic UI)', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+
+    it('bower.json name field is lower case', function() {
+      assert.fileContent('webTest/bower.json', /"name": "webtest"/);
+    });
   });
 
 
@@ -681,6 +689,10 @@ describe('aspnet - Web Application Basic (Bootstrap)', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+
+    it('bower.json name field is lower case', function() {
+      assert.fileContent('webTest/bower.json', /"name": "webtest"/);
+    });
   });
 
 });
@@ -779,6 +791,10 @@ describe('aspnet - Web Application Basic (Semantic UI)', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+
+    it('bower.json name field is lower case', function() {
+      assert.fileContent('webTest/bower.json', /"name": "webtest"/);
+    });
   });
 
   describe('Checking file content for overrides', function() {


### PR DESCRIPTION
/cc
@OmniSharp/generator-aspnet-team-push

The name field meta key should be lower case
otherwise Bower renders a warning to users:
bower invalid-meta The "name" is recommended
to be lowercase, can contain digits, dots, dashes

The changes include:
- actual changes in bower.json templates
- test coverage

Thanks!