### PR TITLE
Update/npm dependencies for RC2

### DIFF
--- a/templates/projects/web/package.json
+++ b/templates/projects/web/package.json
@@ -7,7 +7,7 @@
     "gulp-concat": "2.6.0",
     "gulp-cssmin": "0.1.7",
     "gulp-uglify": "1.5.3",
-    "rimraf": "2.2.8"<% } %><% if(grunt){ %>
+    "rimraf": "2.5.2"<% } %><% if(grunt){ %>
     "grunt": "0.4.5"<% } %>
   }
 }

--- a/templates/projects/web/package.json
+++ b/templates/projects/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {<% if(!grunt){ %>
-    "gulp": "^3.9.0",
+    "gulp": "3.9.1",
     "gulp-concat": "2.5.2",
     "gulp-cssmin": "0.1.7",
     "gulp-uglify": "1.2.0",

--- a/templates/projects/web/package.json
+++ b/templates/projects/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {<% if(!grunt){ %>
     "gulp": "3.9.1",
-    "gulp-concat": "2.5.2",
+    "gulp-concat": "2.6.0",
     "gulp-cssmin": "0.1.7",
     "gulp-uglify": "1.2.0",
     "rimraf": "2.2.8"<% } %><% if(grunt){ %>

--- a/templates/projects/web/package.json
+++ b/templates/projects/web/package.json
@@ -8,6 +8,6 @@
     "gulp-cssmin": "0.1.7",
     "gulp-uglify": "1.5.3",
     "rimraf": "2.5.2"<% } %><% if(grunt){ %>
-    "grunt": "0.4.5"<% } %>
+    "grunt": "1.0.1"<% } %>
   }
 }

--- a/templates/projects/web/package.json
+++ b/templates/projects/web/package.json
@@ -6,7 +6,7 @@
     "gulp": "3.9.1",
     "gulp-concat": "2.6.0",
     "gulp-cssmin": "0.1.7",
-    "gulp-uglify": "1.2.0",
+    "gulp-uglify": "1.5.3",
     "rimraf": "2.2.8"<% } %><% if(grunt){ %>
     "grunt": "0.4.5"<% } %>
   }

--- a/templates/projects/webbasic/package.json
+++ b/templates/projects/webbasic/package.json
@@ -7,7 +7,7 @@
     "gulp-concat": "2.6.0",
     "gulp-cssmin": "0.1.7",
     "gulp-uglify": "1.5.3",
-    "rimraf": "2.2.8"<% } %><% if(grunt){ %>
+    "rimraf": "2.5.2"<% } %><% if(grunt){ %>
     "grunt": "0.4.5"<% } %>
   }
 }

--- a/templates/projects/webbasic/package.json
+++ b/templates/projects/webbasic/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {<% if(!grunt){ %>
-    "gulp": "^3.9.0",
+    "gulp": "3.9.1",
     "gulp-concat": "2.5.2",
     "gulp-cssmin": "0.1.7",
     "gulp-uglify": "1.2.0",

--- a/templates/projects/webbasic/package.json
+++ b/templates/projects/webbasic/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {<% if(!grunt){ %>
     "gulp": "3.9.1",
-    "gulp-concat": "2.5.2",
+    "gulp-concat": "2.6.0",
     "gulp-cssmin": "0.1.7",
     "gulp-uglify": "1.2.0",
     "rimraf": "2.2.8"<% } %><% if(grunt){ %>

--- a/templates/projects/webbasic/package.json
+++ b/templates/projects/webbasic/package.json
@@ -8,6 +8,6 @@
     "gulp-cssmin": "0.1.7",
     "gulp-uglify": "1.5.3",
     "rimraf": "2.5.2"<% } %><% if(grunt){ %>
-    "grunt": "0.4.5"<% } %>
+    "grunt": "1.0.1"<% } %>
   }
 }

--- a/templates/projects/webbasic/package.json
+++ b/templates/projects/webbasic/package.json
@@ -6,7 +6,7 @@
     "gulp": "3.9.1",
     "gulp-concat": "2.6.0",
     "gulp-cssmin": "0.1.7",
-    "gulp-uglify": "1.2.0",
+    "gulp-uglify": "1.5.3",
     "rimraf": "2.2.8"<% } %><% if(grunt){ %>
     "grunt": "0.4.5"<% } %>
   }


### PR DESCRIPTION
/cc
@OmniSharp/generator-aspnet-team-push

NPM updated for:
- Gulp (local)
- gulp-concat
- gulp-uglify
- rimraf
- Grunt (local)
- all dependencies use blank (not tilde or caret) versioning

See: aspnet/Templates#549

This was tested locally with NPM 3.*, Node 4.*

Thanks!