### PR TITLE
Move mkdirp to regular dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "chai": "^3.3.0",
     "chalk": "^1.1.3",
     "findup-sync": "^0.3.0",
+    "mkdirp": "^0.5.1",
     "nconf": "^0.8.2",
     "uuid": "^2.0.1",
     "vs_projectname": "^1.0.0",
@@ -60,7 +61,6 @@
     "yosay": "^1.1.1"
   },
   "devDependencies": {
-    "mkdirp": "^0.5.1",
     "mocha": "^2.3.3"
   },
   "scripts": {


### PR DESCRIPTION
/ccc
@OmniSharp/generator-aspnet-team-push

The mkdirp is technicaly runtime dependency for client
side installation - not development.
Is used by subgenerator and will be used by project
templates to create empty directories like wwwroot

Thanks!