### PR TITLE
Update WebAPI application for RC2. Closes #703

### DIFF
--- a/templates/projects/webapi/Properties/launchSettings.json
+++ b/templates/projects/webapi/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:24446/",
+      "applicationUrl": "http://localhost:55368/",
       "sslPort": 0
     }
   },

--- a/templates/projects/webapi/project.json
+++ b/templates/projects/webapi/project.json
@@ -1,23 +1,23 @@
 {
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.0.0-rc2-3002611",
+      "version": "1.0.0-rc2-3002702",
       "type": "platform"
     },
-    "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-20801",
-    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-20801",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20801",
-    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-20801",
-    "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-rc2-20801",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-20801",
-    "Microsoft.Extensions.Logging": "1.0.0-rc2-20801",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20801",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-20801"
+    "Microsoft.AspNetCore.Mvc": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final"
   },
 
   "tools": {
     "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
-      "version": "1.0.0-rc2-20801",
+      "version": "1.0.0-preview1-final",
       "imports": "portable-net45+win8+dnxcore50"
     }
   },


### PR DESCRIPTION
/cc
@OmniSharp/generator-aspnet-team-push

The final bits of RC2
Tested with 1.0.0-preview1-002702


```
dotnet run
Project WebAPIApplication (.NETCoreApp,Version=v1.0) was previously compiled. Skipping compilation.
Hosting environment: Production
Content root path: /Users/piotrblazejewicz/development/WebAPIApplication
Now listening on: http://localhost:5000
Application started. Press Ctrl+C to shut down.
info: Microsoft.AspNetCore.Hosting.Internal.WebHost[1]
      Request starting HTTP/1.1 GET http://localhost:5000/  
info: Microsoft.AspNetCore.Hosting.Internal.WebHost[2]
      Request finished in 337.0909ms 404 
info: Microsoft.AspNetCore.Hosting.Internal.WebHost[1]
      Request starting HTTP/1.1 GET http://localhost:5000/api/values  
info: Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker[1]
      Executing action method WebAPIApplication.Controllers.ValuesController.Get (WebAPIApplication) with arguments () - ModelState is Valid'
info: Microsoft.AspNetCore.Mvc.Internal.ObjectResultExecutor[1]
      Executing ObjectResult, writing value Microsoft.AspNetCore.Mvc.ControllerContext.
info: Microsoft.AspNetCore.Mvc.Internal.MvcRouteHandler[2]
      Executed action WebAPIApplication.Controllers.ValuesController.Get (WebAPIApplication) in 388.6097ms
info: Microsoft.AspNetCore.Hosting.Internal.WebHost[2]
      Request finished in 490.487ms 200 application/json; charset=utf-8
```