### PR TITLE
Update/dockerfile

### DIFF
--- a/Dockerfile/USAGE
+++ b/Dockerfile/USAGE
@@ -1,10 +1,8 @@
 Description:
     Creates a new Docker configuration file.
-    By default Mono-based definition file is created.
-    To create CoreCLR based definition file use --coreclr option
 
 Example:
-    yo aspnet:Dockerfile [--coreclr]
+    yo aspnet:Dockerfile
 
     This will create:
         Dockerfile

--- a/Dockerfile/index.js
+++ b/Dockerfile/index.js
@@ -9,11 +9,7 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createItem = function() {
-  // support CoreCLR runtime version of Docker image
-  // is provided by --coreclr option
   this.generateTemplateFile(
-    'Dockerfile.txt', 
-    'Dockerfile', {
-      coreclr: (this.options.coreclr) ? this.options.coreclr : false
-  });
+    'Dockerfile.txt',
+    'Dockerfile');
 };

--- a/README.md
+++ b/README.md
@@ -252,8 +252,6 @@ Produces `filename.coffee`
 ### Dockerfile
 
 Creates a new Docker configuration file.
-By default `Mono` based definition file is created.
-To create `CoreCLR` based definition file use `--coreclr` option
 
 Example:
 ```

--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.0.0-rc2
+FROM microsoft/dotnet:1.0.0-rc2-core
 
 RUN printf "deb http://ftp.us.debian.org/debian jessie main\n" >> /etc/apt/sources.list
 RUN apt-get -qq update && apt-get install -qqy sqlite3 libsqlite3-dev && rm -rf /var/lib/apt/lists/*

--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -1,11 +1,11 @@
-<% if(!coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-update1<% } %><% if(coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-update1-coreclr<% } %>
+FROM microsoft/dotnet:1.0.0-rc2
 
 RUN printf "deb http://ftp.us.debian.org/debian jessie main\n" >> /etc/apt/sources.list
 RUN apt-get -qq update && apt-get install -qqy sqlite3 libsqlite3-dev && rm -rf /var/lib/apt/lists/*
 
 COPY . /app
 WORKDIR /app
-RUN ["dnu", "restore"]
+RUN ["dotnet", "restore"]
 
 EXPOSE 5000/tcp
-ENTRYPOINT ["dnx", "-p", "project.json", "Microsoft.AspNet.Server.Kestrel", "--server.urls", "http://0.0.0.0:5000"]
+ENTRYPOINT ["dotnet", "run", "-p", "project.json"]

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -103,7 +103,7 @@ describe('Subgenerators without arguments tests', function() {
     var filename = 'Dockerfile';
     util.goCreate(filename);
     util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for dotnet image tag', /FROM microsoft\/dotnet:1\.0\.0-rc2/);
+    util.fileContentCheck(filename, 'Check the content for dotnet image tag', /FROM microsoft\/dotnet:1\.0\.0-rc2-core/);
   });
 
   describe('aspnet:nuget', function() {

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -99,19 +99,11 @@ describe('Subgenerators without arguments tests', function() {
     util.fileCheck('should create tsconfig.json file', 'tsconfig.json');
   });
 
-  describe('aspnet:Dockerfile Mono-based', function() {
+  describe('aspnet:Dockerfile', function() {
     var filename = 'Dockerfile';
     util.goCreate(filename);
     util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for Mono-based image tag', /FROM microsoft\/aspnet:1\.0\.0-rc1-update1/);
-  });
-
-  describe('aspnet:Dockerfile CoreCLR-based', function() {
-    var arg = '--coreclr';
-    var filename = 'Dockerfile';
-    util.goCreateWithArgs(filename, [arg]);
-    util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for CoreCLR-based image tag', /FROM microsoft\/aspnet:1\.0\.0-rc1-update1-coreclr/);
+    util.fileContentCheck(filename, 'Check the content for dotnet image tag', /FROM microsoft\/dotnet:1\.0\.0-rc2/);
   });
 
   describe('aspnet:nuget', function() {


### PR DESCRIPTION
This is the fist effort for updated Dockerfile supporting `rc2` and `dotnet` runtime.
I had limited success running it on my Mac and it certainly requires some work.

At the moment the run fails with `Did not find a suitable dotnet SDK at '/usr/share/dotnet'. Install dotnet SDK from https://github.com/dotnet/cli`

/cc @spboyer @glennc 

The `-p` option is supported in `dotnet-cli` but `--server-urls` support needs to be determined

Thanks!