### PR TITLE
Add EF migration usage hints for RC2 web template

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ The Empty Web Application, Console Application, Web Application, Web Application
 
 > [ASP.NET Templates](https://github.com/aspnet/Templates) project provides templates which are used in Visual Studio for creating ASP.NET Core 1.0 applications.
 
+> NOTE: Starting from `RC2` `dotnet` release the web application template project no longer ships with built-in EF migration. For this reason you should call `dotnet ef database update` to scaffold database using template provided migrations!
+
 The Nancy project is based on framework's "Hello World" template:
 [Nancy Getting Started: Introduction](https://github.com/NancyFx/Nancy/wiki/Introduction)
 

--- a/app/index.js
+++ b/app/index.js
@@ -362,6 +362,9 @@ var AspnetGenerator = yeoman.generators.Base.extend({
     this.log(chalk.green('    cd "' + this.applicationName + '"'));
     this.log(chalk.green('    dotnet restore'));
     this.log(chalk.green('    dotnet build') + ' (optional, build will also happen when it\'s run)');
+    if(this.type === 'web') {
+      this.log(chalk.green('    dotnet ef database update') + ' (to create the SQLite database for the project)');
+    }
     switch (this.type) {
       case 'consoleapp':
         this.log(chalk.green('    dotnet run'));


### PR DESCRIPTION
/cc
@OmniSharp/generator-aspnet-team-push

EF migrations are now not built-into templates
let users to know how to scaffold database using code-first scenario
with saved migrations

See #713 comments