### PR TITLE
Dockerfile for RC2. Fixes #685

### DIFF
--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -1,11 +1,11 @@
-<% if(!coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-update1<% } %><% if(coreclr){ %>FROM microsoft/aspnet:1.0.0-rc1-update1-coreclr<% } %>
-
+FROM microsoft/dotnet:latest
+ 
 RUN printf "deb http://ftp.us.debian.org/debian jessie main\n" >> /etc/apt/sources.list
-RUN apt-get -qq update && apt-get install -qqy sqlite3 libsqlite3-dev && rm -rf /var/lib/apt/lists/*
-
+ 
 COPY . /app
 WORKDIR /app
-RUN ["dnu", "restore"]
-
+RUN ["dotnet", "restore"]
+RUN ["dotnet", "build"]
+ 
 EXPOSE 5000/tcp
-ENTRYPOINT ["dnx", "-p", "project.json", "Microsoft.AspNet.Server.Kestrel", "--server.urls", "http://0.0.0.0:5000"]
+ENTRYPOINT ["dotnet", "run", "--server.urls", "http://0.0.0.0:5000"]

--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -1,7 +1,5 @@
 FROM microsoft/dotnet:latest
  
-RUN printf "deb http://ftp.us.debian.org/debian jessie main\n" >> /etc/apt/sources.list
- 
 COPY . /app
 WORKDIR /app
 RUN ["dotnet", "restore"]

--- a/templates/projects/emptyweb/Program.cs
+++ b/templates/projects/emptyweb/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 
 namespace <%= namespace %>
 {
@@ -11,7 +12,13 @@ namespace <%= namespace %>
     {
         public static void Main(string[] args)
         {
+           var config = new ConfigurationBuilder()
+                .AddCommandLine(args)
+                .AddEnvironmentVariables(prefix: "ASPNETCORE_")
+                .Build();
+            
             var host = new WebHostBuilder()
+                .UseConfiguration(config)
                 .UseKestrel()
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()

--- a/templates/projects/emptyweb/project.json
+++ b/templates/projects/emptyweb/project.json
@@ -5,7 +5,11 @@
       "type": "platform"
     },
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final"
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",    
+    "Microsoft.Extensions.Configuration.CommandLine": "1.0.0-rc2-final"
   },
 
   "tools": {

--- a/templates/projects/web/Program.cs
+++ b/templates/projects/web/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 
 namespace <%= namespace %>
 {
@@ -11,7 +12,13 @@ namespace <%= namespace %>
     {
         public static void Main(string[] args)
         {
+            var config = new ConfigurationBuilder()
+                .AddCommandLine(args)
+                .AddEnvironmentVariables(prefix: "ASPNETCORE_")
+                .Build();
+                            
             var host = new WebHostBuilder()
+                .UseConfiguration(config)
                 .UseKestrel()
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()

--- a/templates/projects/web/project.json
+++ b/templates/projects/web/project.json
@@ -25,6 +25,7 @@
     },
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.CommandLine": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",

--- a/templates/projects/webapi/Program.cs
+++ b/templates/projects/webapi/Program.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
 
 namespace <%= namespace %>
 {
@@ -12,7 +13,13 @@ namespace <%= namespace %>
     {
         public static void Main(string[] args)
         {
+            var config = new ConfigurationBuilder()
+                .AddCommandLine(args)
+                .AddEnvironmentVariables(prefix: "ASPNETCORE_")
+                .Build();
+            
             var host = new WebHostBuilder()
+                .UseConfiguration(config)
                 .UseKestrel()
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()

--- a/templates/projects/webapi/project.json
+++ b/templates/projects/webapi/project.json
@@ -10,6 +10,7 @@
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.CommandLine": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final"

--- a/templates/projects/webbasic/Program.cs
+++ b/templates/projects/webbasic/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 
 namespace <%= namespace %>
 {
@@ -11,7 +12,13 @@ namespace <%= namespace %>
     {
         public static void Main(string[] args)
         {
+            var config = new ConfigurationBuilder()
+                .AddCommandLine(args)
+                .AddEnvironmentVariables(prefix: "ASPNETCORE_")
+                .Build();
+
             var host = new WebHostBuilder()
+                .UseConfiguration(config)
                 .UseKestrel()
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()

--- a/templates/projects/webbasic/project.json
+++ b/templates/projects/webbasic/project.json
@@ -15,6 +15,7 @@
     "Microsoft.AspNetCore.StaticFiles": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Configuration.CommandLine": "1.0.0-rc2-final",    
     "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
     "Microsoft.Extensions.Logging.Debug": "1.0.0-rc2-final",

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -99,19 +99,11 @@ describe('Subgenerators without arguments tests', function() {
     util.fileCheck('should create tsconfig.json file', 'tsconfig.json');
   });
 
-  describe('aspnet:Dockerfile Mono-based', function() {
+  describe('aspnet:Dockerfile dotnet', function() {
     var filename = 'Dockerfile';
     util.goCreate(filename);
     util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for Mono-based image tag', /FROM microsoft\/aspnet:1\.0\.0-rc1-update1/);
-  });
-
-  describe('aspnet:Dockerfile CoreCLR-based', function() {
-    var arg = '--coreclr';
-    var filename = 'Dockerfile';
-    util.goCreateWithArgs(filename, [arg]);
-    util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for CoreCLR-based image tag', /FROM microsoft\/aspnet:1\.0\.0-rc1-update1-coreclr/);
+    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:latest/);    
   });
 
   describe('aspnet:nuget', function() {


### PR DESCRIPTION
Fixes #685.

Summary of the changes in this PR:

- Modified Dockerfile.txt template to fit dotnet cli commands (restore, build...)
- Added Microsoft.Extensions.Configuration.CommandLine NuGet package to project.json web, webapi and web basic templates
- Added CommandLine ConfigurationBuilder to fix Kestrel endpoint configuration through Dockerfile ENTRYPOINT

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push

Added ConfigurationBuilder to WebHostBuilder for Dockerfile launch configuration