### PR TITLE
🐳 Dockerfile support refactoring with optional SQLite support

### DIFF
--- a/Dockerfile/USAGE
+++ b/Dockerfile/USAGE
@@ -1,10 +1,10 @@
 Description:
     Creates a new Docker configuration file.
-    By default Mono-based definition file is created.
-    To create CoreCLR based definition file use --coreclr option
+    To create Docker image with SQLite support for EntityFramework
+    use --sqlite option
 
 Example:
-    yo aspnet:Dockerfile [--coreclr]
+    yo aspnet:Dockerfile [--sqlite]
 
     This will create:
         Dockerfile

--- a/Dockerfile/index.js
+++ b/Dockerfile/index.js
@@ -9,11 +9,11 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createItem = function() {
-  // support CoreCLR runtime version of Docker image
-  // is provided by --coreclr option
+  // support SQLite library is provided by sqlite option
+  // is provided by --sqlite option
   this.generateTemplateFile(
-    'Dockerfile.txt', 
+    'Dockerfile.txt',
     'Dockerfile', {
-      coreclr: (this.options.coreclr) ? this.options.coreclr : false
+      sqlite: (this.options.sqlite) ? this.options.sqlite : false
   });
 };

--- a/README.md
+++ b/README.md
@@ -257,8 +257,7 @@ Produces `filename.coffee`
 ### Dockerfile
 
 Creates a new Docker configuration file.
-By default `Mono` based definition file is created.
-To create `CoreCLR` based definition file use `--coreclr` option
+To create Docker image with SQLite support for EntityFramework use `--sqlite` option
 
 Example:
 ```

--- a/app/index.js
+++ b/app/index.js
@@ -116,7 +116,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
     this.templatedata.applicationname = this.applicationName;
     this.templatedata.guid = guid.v4();
     this.templatedata.grunt = this.options.grunt || false;
-    this.templatedata.coreclr = this.options.coreclr || false;
+    this.templatedata.sqlite = (this.type === 'web') ? true : false;
     this.templatedata.ui = this.ui;
   },
 

--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -1,9 +1,17 @@
 FROM microsoft/dotnet:latest
- 
+<% if(sqlite){ %>
+RUN apt-get update && apt-get install sqlite3 libsqlite3-dev
+<% } %>
 COPY . /app
+
 WORKDIR /app
+
 RUN ["dotnet", "restore"]
+
 RUN ["dotnet", "build"]
- 
+<% if(sqlite){ %>
+RUN ["dotnet", "ef", "database", "update"]
+<% } %>
 EXPOSE 5000/tcp
+
 ENTRYPOINT ["dotnet", "run", "--server.urls", "http://0.0.0.0:5000"]

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -99,11 +99,28 @@ describe('Subgenerators without arguments tests', function() {
     util.fileCheck('should create tsconfig.json file', 'tsconfig.json');
   });
 
+  /**
+   * Dockerfile can be created with two versions:
+   * - without SQLite installed
+   * - with SQLite installed and EF migrations called
+   */
   describe('aspnet:Dockerfile dotnet', function() {
     var filename = 'Dockerfile';
     util.goCreate(filename);
     util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:latest/);    
+    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:latest/);
+    util.noFileContentCheck(filename, 'Does not contain SQLite install', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+    util.noFileContentCheck(filename, 'Does not call database migrations', /RUN \["dotnet", "ef", "database", "update"\]/);
+  });
+
+  describe('aspnet:Dockerfile dotnet with --sqlite', function() {
+    var arg = '--sqlite';
+    var filename = 'Dockerfile';
+    util.goCreateWithArgs(filename, [arg]);
+    util.fileCheck('should create Dockerfile', filename);
+    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:latest/);
+    util.fileContentCheck(filename, 'Contains SQLite install', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+    util.fileContentCheck(filename, 'Calls database migrations', /RUN \["dotnet", "ef", "database", "update"\]/);
   });
 
   describe('aspnet:nuget', function() {

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -50,6 +50,15 @@ describe('aspnet - Empty Web Application', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+
+    it('Dockerfile does not include SQLite', function() {
+      assert.noFileContent('emptyWebTest/Dockerfile', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+    });
+
+    it('Dockerfile does not contain migrations', function() {
+      assert.noFileContent('emptyWebTest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
+    });
+
   });
 
 });
@@ -288,6 +297,15 @@ describe('aspnet - Web Application (Bootstrap)', function() {
     it('bower.json name field is lower case', function() {
       assert.fileContent('webTest/bower.json', /"name": "webtest"/);
     });
+
+    it('Dockerfile includes SQLite', function() {
+      assert.fileContent('webTest/Dockerfile', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+    });
+
+    it('Dockerfile contains migrations', function() {
+      assert.fileContent('webTest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
+    });
+
   });
 
 });
@@ -457,6 +475,15 @@ describe('aspnet - Web Application (Semantic UI)', function() {
     it('bower.json name field is lower case', function() {
       assert.fileContent('webTest/bower.json', /"name": "webtest"/);
     });
+
+    it('Dockerfile includes SQLite', function() {
+      assert.fileContent('webTest/Dockerfile', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+    });
+
+    it('Dockerfile contains migrations', function() {
+      assert.fileContent('webTest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
+    });
+
   });
 
 
@@ -597,6 +624,15 @@ describe('aspnet - Web Application Basic (Bootstrap)', function() {
     it('bower.json name field is lower case', function() {
       assert.fileContent('webTest/bower.json', /"name": "webtest"/);
     });
+
+    it('Dockerfile does not include SQLite', function() {
+      assert.noFileContent('webTest/Dockerfile', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+    });
+
+    it('Dockerfile does not contain migrations', function() {
+      assert.noFileContent('webTest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
+    });
+
   });
 
 });
@@ -697,6 +733,15 @@ describe('aspnet - Web Application Basic (Semantic UI)', function() {
     it('bower.json name field is lower case', function() {
       assert.fileContent('webTest/bower.json', /"name": "webtest"/);
     });
+
+    it('Dockerfile does not include SQLite', function() {
+      assert.noFileContent('webTest/Dockerfile', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+    });
+
+    it('Dockerfile does not contain migrations', function() {
+      assert.noFileContent('webTest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
+    });
+
   });
 
   describe('Checking file content for overrides', function() {
@@ -777,6 +822,15 @@ describe('aspnet - Web API Application', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+
+    it('Dockerfile does not include SQLite', function() {
+      assert.noFileContent('webAPITest/Dockerfile', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+    });
+
+    it('Dockerfile does not contain migrations', function() {
+      assert.noFileContent('webAPITest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
+    });
+
   });
 
 });


### PR DESCRIPTION
This PR adds optional support for SQLite package added to generated Docker image - as required by web starter project with individual accounts (SQLite backed EF).

The PR introduces explicit `--sqlite` option for `Dockerfile` subgenerator and implicit `--sqlite` option set to true when scaffolding project of type `web` (starter web with EF + SQLite).

The PR introduces changes in unit tests to cover all scenarios for Dockerfile creation

For details about implementation:
https://github.com/OmniSharp/generator-aspnet/pull/743

Thanks!

/cc
@sesispla
@OmniSharp/generator-aspnet-team-push
