### PR TITLE
:fire: Remove exclusions of node_modules folder from compilation

### DIFF
--- a/templates/projects/emptyweb/project.json
+++ b/templates/projects/emptyweb/project.json
@@ -31,12 +31,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-     "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 
   "runtimeOptions": {

--- a/templates/projects/unittest/project.json
+++ b/templates/projects/unittest/project.json
@@ -2,12 +2,7 @@
   "version": "1.0.0-*",
 
   "buildOptions": {
-    "preserveCompilationContext": true,
-     "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 
   "dependencies": {

--- a/templates/projects/web/project.json
+++ b/templates/projects/web/project.json
@@ -90,12 +90,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-     "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 
   "runtimeOptions": {

--- a/templates/projects/webapi/project.json
+++ b/templates/projects/webapi/project.json
@@ -36,12 +36,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-     "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 
   "runtimeOptions": {

--- a/templates/projects/webbasic/project.json
+++ b/templates/projects/webbasic/project.json
@@ -53,12 +53,7 @@
 
   "buildOptions": {
     "emitEntryPoint": true,
-    "preserveCompilationContext": true,
-     "compile": {
-      "exclude": [
-        "node_modules"
-      ]
-    }
+    "preserveCompilationContext": true
   },
 
   "runtimeOptions": {


### PR DESCRIPTION
/cc
@OmniSharp/generator-aspnet-team-push

This rule affects dotnet build action - mind this when building a content with NPM dependencies (say with Angular 2 projects).
It is removed because of direct NPM modules dependency removal from templates.
For details please see:
aspnet/Templates#603

Thanks!