### PR TITLE
Add logging and diagnostic pages to empty

### DIFF
--- a/templates/projects/emptyweb/Startup.cs
+++ b/templates/projects/emptyweb/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace <%= namespace %>
 {
@@ -18,8 +19,15 @@ namespace <%= namespace %>
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
+            loggerFactory.AddConsole();
+
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
             app.Run(async (context) =>
             {
                 await context.Response.WriteAsync("Hello World!");

--- a/templates/projects/emptyweb/project.json
+++ b/templates/projects/emptyweb/project.json
@@ -4,11 +4,13 @@
       "version": "1.0.0-rc2-3002702",
       "type": "platform"
     },
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0-rc2-final",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0-rc2-final",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",    
+    "Microsoft.Extensions.Configuration.Json": "1.0.0-rc2-final",
     "Microsoft.Extensions.Configuration.CommandLine": "1.0.0-rc2-final"
   },
 


### PR DESCRIPTION
/cc
@OmniSharp/generator-aspnet-team-push

This commit brings changes from aspnet/Templates#611
to empty web application template

The commit contains some minor changes required resulted from
adding changes to project not found in original
aspnet/Templates#611 PR

Thanks!