### PR TITLE
:trash: Remove unneeded imports in project.json [WIP]

### DIFF
--- a/templates/projects/emptyweb/project.json
+++ b/templates/projects/emptyweb/project.json
@@ -13,17 +13,13 @@
   },
 
   "tools": {
-    "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
-      "version": "1.0.0-preview1-final",
-      "imports": "portable-net45+win8+dnxcore50"
-    }
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview1-final"
   },
 
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
         "dotnet5.6",
-        "dnxcore50",
         "portable-net45+win8"
       ]
     }

--- a/templates/projects/web/project.json
+++ b/templates/projects/web/project.json
@@ -46,18 +46,11 @@
     "BundlerMinifier.Core": {
       "version": "2.0.231",
       "imports": [
-        "portable-net45+win8+dnxcore50",
-        "portable-net40+sl5+win8+wp8+wpa81"
+        "portable-net45+win8+dnxcore50"
       ]
     },
-    "Microsoft.AspNetCore.Razor.Tools": {
-      "version": "1.0.0-preview1-final",
-      "imports": "portable-net45+win8+dnxcore50"
-    },
-    "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
-      "version": "1.0.0-preview1-final",
-      "imports": "portable-net45+win8+dnxcore50"
-    },
+    "Microsoft.AspNetCore.Razor.Tools": "1.0.0-preview1-final",
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview1-final",
     "Microsoft.EntityFrameworkCore.Tools": {
       "version": "1.0.0-preview1-final",
       "imports": [
@@ -65,14 +58,10 @@
         "portable-net45+win8"
       ]
     },
-    "Microsoft.Extensions.SecretManager.Tools": {
-      "version": "1.0.0-preview1-final",
-      "imports": "portable-net45+win8+dnxcore50"
-    },
+    "Microsoft.Extensions.SecretManager.Tools": "1.0.0-preview1-final",
     "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
       "version": "1.0.0-preview1-final",
       "imports": [
-        "portable-net45+win8+dnxcore50",
         "portable-net45+win8"
       ]
     }
@@ -82,7 +71,6 @@
     "netcoreapp1.0": {
       "imports": [
         "dotnet5.6",
-        "dnxcore50",
         "portable-net45+win8"
       ]
     }

--- a/templates/projects/webapi/project.json
+++ b/templates/projects/webapi/project.json
@@ -18,17 +18,13 @@
   },
 
   "tools": {
-    "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
-      "version": "1.0.0-preview1-final",
-      "imports": "portable-net45+win8+dnxcore50"
-    }
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview1-final"
   },
 
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
         "dotnet5.6",
-        "dnxcore50",
         "portable-net45+win8"
       ]
     }

--- a/templates/projects/webbasic/project.json
+++ b/templates/projects/webbasic/project.json
@@ -27,25 +27,17 @@
     "BundlerMinifier.Core": {
       "version": "2.0.231",
       "imports": [
-        "portable-net45+win8+dnxcore50",
-        "portable-net40+sl5+win8+wp8+wpa81"
+        "portable-net45+win8+dnxcore50"
       ]
     },
-    "Microsoft.AspNetCore.Razor.Tools": {
-      "version": "1.0.0-preview1-final",
-      "imports": "portable-net45+win8+dnxcore50"
-    },
-    "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
-      "version": "1.0.0-preview1-final",
-      "imports": "portable-net45+win8+dnxcore50"
-    }
+    "Microsoft.AspNetCore.Razor.Tools": "1.0.0-preview1-final",
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview1-final"
   },
 
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
         "dotnet5.6",
-        "dnxcore50",
         "portable-net45+win8"
       ]
     }


### PR DESCRIPTION
/cc
@OmniSharp/generator-aspnet-team-push

This commit brings changes from:
aspnet/Templates#619

Thanks!

Do not merge this PR yet. The projects won't restore correctly:
```
log  : Restoring packages for tool 'Microsoft.AspNetCore.Server.IISIntegration.Tools' in /Users/piotrblazejewicz/development/WebAPIApplication/project.json...
error: Package Newtonsoft.Json 7.0.1 is not compatible with netcoreapp1.0 (.NETCoreApp,Version=v1.0). Package Newtonsoft.Json 7.0.1 supports:
error:   - net20 (.NETFramework,Version=v2.0)
error:   - net35 (.NETFramework,Version=v3.5)
error:   - net40 (.NETFramework,Version=v4.0)
error:   - net45 (.NETFramework,Version=v4.5)
error:   - portable-dnxcore50+net45+win8+wp8+wpa81 (.NETPortable,Version=v0.0,Profile=net45+wp80+win8+wpa81+dnxcore50)
error:   - portable-net40+sl5+win8+wp8+wpa81 (.NETPortable,Version=v0.0,Profile=Profile328)
error: One or more packages are incompatible with .NETCoreApp,Version=v1.0.
```
as the correct configuration should be established first (NuGet packages version if released, etc).

