### PR TITLE
Remove imports for BundlerMinifier from project.json [WIP]

### DIFF
--- a/templates/projects/web/project.json
+++ b/templates/projects/web/project.json
@@ -43,13 +43,7 @@
   },
 
   "tools": {
-    "BundlerMinifier.Core": {
-      "version": "2.0.231",
-      "imports": [
-        "portable-net45+win8+dnxcore50",
-        "portable-net40+sl5+win8+wp8+wpa81"
-      ]
-    },
+    "BundlerMinifier.Core": "2.0.231",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "1.0.0-preview1-final",
       "imports": "portable-net45+win8+dnxcore50"

--- a/templates/projects/webbasic/project.json
+++ b/templates/projects/webbasic/project.json
@@ -24,13 +24,7 @@
   },
 
   "tools": {
-    "BundlerMinifier.Core": {
-      "version": "2.0.231",
-      "imports": [
-        "portable-net45+win8+dnxcore50",
-        "portable-net40+sl5+win8+wp8+wpa81"
-      ]
-    },
+    "BundlerMinifier.Core": "2.0.231",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "1.0.0-preview1-final",
       "imports": "portable-net45+win8+dnxcore50"


### PR DESCRIPTION
This should wait for RTM runtime tools before merging (it does not work under current dontet version)

/cc
@OmniSharp/generator-aspnet-team-push

This commit brings changes from:
aspnet/Templates@64d245a

Thanks!