### PR TITLE
Revert ":memo: Update README with RTM warning [skip ci] (#763)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-> NOTE: The `master` branch of this project is currently under active rewrite for upcoming major update of ASP.NET Core. Please use published NPM version - unless you want to contribute to upcoming release. Thanks!
-
 # generator-aspnet
 
 [![Build Status](https://travis-ci.org/OmniSharp/generator-aspnet.svg?branch=master)](https://travis-ci.org/OmniSharp/generator-aspnet)


### PR DESCRIPTION
Wait before merging this until @sayedihashimi confirms RTM is ready to ship (so before publishing generator update to NPM)

/cc
@OmniSharp/generator-aspnet-team-push

This removes warning banner on the top of README.md
Merge this commit before making public release but left
until all changes for RTM are not yet merged into master

Thanks!

edit: `bunner`? LoL