### PR TITLE
:arrow_up: Update Nancy template for RTM. Closes #775 [WIP]

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -276,16 +276,18 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         break;
       case 'nancy':
         this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
-
         this.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '/.gitignore');
-
-        this.template(this.sourceRoot() + '/Startup.cs', this.applicationName + '/Startup.cs', this.templatedata);
-
-        this.fs.copyTpl(this.sourceRoot() + '/project.json', this.applicationName + '/project.json', this.templatedata);
-
+        this.template(this.sourceRoot() + '/AppConfiguration.cs', this.applicationName + '/AppConfiguration.cs', this.templatedata);
+        this.fs.copyTpl(this.sourceRoot() + '/appsettings.json', this.applicationName + '/appsettings.json', this.templatedata);
+        this.template(this.sourceRoot() + '/DemoBootstrapper.cs', this.applicationName + '/DemoBootstrapper.cs', this.templatedata);
         this.template(this.sourceRoot() + '/HomeModule.cs', this.applicationName + '/HomeModule.cs', this.templatedata);
-
+        this.template(this.sourceRoot() + '/Person.cs', this.applicationName + '/Person.cs', this.templatedata);
+        this.template(this.sourceRoot() + '/PersonValidator.cs', this.applicationName + '/PersonValidator.cs', this.templatedata);
+        this.template(this.sourceRoot() + '/Program.cs', this.applicationName + '/Program.cs', this.templatedata);
+        this.fs.copyTpl(this.sourceRoot() + '/project.json', this.applicationName + '/project.json', this.templatedata);
+        this.template(this.sourceRoot() + '/Startup.cs', this.applicationName + '/Startup.cs', this.templatedata);
         break;
+
       case 'consoleapp':
         this.sourceRoot(path.join(__dirname, '../templates/projects/consoleapp'));
         this.fs.copy(path.join(__dirname, '../templates/gitignore.txt'), this.applicationName + '/.gitignore');

--- a/templates/projects/nancy/AppConfiguration.cs
+++ b/templates/projects/nancy/AppConfiguration.cs
@@ -1,0 +1,29 @@
+namespace <%= namespace %>
+{
+    public class AppConfiguration
+    {
+        public Logging Logging { get; set; }
+        public Smtp Smtp { get; set; }
+    }
+
+    public class LogLevel
+    {
+        public string Default { get; set; }
+        public string System { get; set; }
+        public string Microsoft { get; set; }
+    }
+
+    public class Logging
+    {
+        public bool IncludeScopes { get; set; }
+        public LogLevel LogLevel { get; set; }
+    }
+
+    public class Smtp
+    {
+        public string Server { get; set; }
+        public string User { get; set; }
+        public string Pass { get; set; }
+        public string Port { get; set; }
+    }
+}

--- a/templates/projects/nancy/DemoBootstrapper.cs
+++ b/templates/projects/nancy/DemoBootstrapper.cs
@@ -1,0 +1,24 @@
+namespace <%= namespace %>
+{
+    using System;
+
+    public class DemoBootstrapper : DefaultNancyBootstrapper
+    {
+        public DemoBootstrapper()
+        {
+
+        }
+
+        public DemoBootstrapper(AppConfiguration appConfig)
+        {
+            /*
+            We could register appConfig as an instance in the container which can
+            be injected into areas that need it or we could create our own INancyEnvironment
+            extension and use that.
+            */
+            Console.WriteLine(appConfig.Smtp.Server);
+            Console.WriteLine(appConfig.Smtp.User);
+            Console.WriteLine(appConfig.Logging.IncludeScopes);
+        }
+    }
+}

--- a/templates/projects/nancy/Person.cs
+++ b/templates/projects/nancy/Person.cs
@@ -1,0 +1,7 @@
+namespace <%= namespace %>
+{
+    public class Person
+    {
+        public string Name { get; set; }
+    }
+}

--- a/templates/projects/nancy/PersonValidator.cs
+++ b/templates/projects/nancy/PersonValidator.cs
@@ -1,0 +1,12 @@
+namespace <%= namespace %>
+{
+    using FluentValidation;
+
+    public class PersonValidator : AbstractValidator<Person>
+    {
+        public PersonValidator()
+        {
+            this.RuleFor(x => x.Name).NotEmpty();
+        }
+    }
+}

--- a/templates/projects/nancy/Program.cs
+++ b/templates/projects/nancy/Program.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+
+namespace <%= namespace %>
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseKestrel()
+                .UseStartup<Startup>()
+                .Build();
+            host.Run();
+        }
+    }
+}

--- a/templates/projects/nancy/Startup.cs
+++ b/templates/projects/nancy/Startup.cs
@@ -1,16 +1,31 @@
 namespace <%= namespace %>
 {
-    using Microsoft.AspNet.Builder;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.Configuration;
     using Nancy.Owin;
- 
+
     public class Startup
     {
-        public void Configure(IApplicationBuilder app)
+        public IConfiguration Configuration { get; set; }
+
+        public Startup(IHostingEnvironment env)
         {
-            app.UseOwin(x => x.UseNancy());
+            var builder = new ConfigurationBuilder()
+                              .AddJsonFile("appsettings.json")
+                              .SetBasePath(env.ContentRootPath);
+
+            Configuration = builder.Build();
         }
 
-        // Entry point for the application.
-        public static void Main(string[] args) => Microsoft.AspNet.Hosting.WebApplication.Run<Startup>(args);
+        public void Configure(IApplicationBuilder app)
+        {
+
+            var config = this.Configuration;
+            var appConfig = new AppConfiguration();
+            ConfigurationBinder.Bind(config, appConfig);
+
+            app.UseOwin(x => x.UseNancy(opt => opt.Bootstrapper = new DemoBootstrapper(appConfig)));
+        }
     }
 }

--- a/templates/projects/nancy/appsettings.json
+++ b/templates/projects/nancy/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Verbose",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  },
+  "Smtp": {
+    "Server": "0.0.0.1",
+    "User": "user@company.com",
+    "Pass": "123456789",
+    "Port": "25"
+  }
+}

--- a/templates/projects/nancy/project.json
+++ b/templates/projects/nancy/project.json
@@ -1,20 +1,34 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
+    "buildOptions": {
+        "debugType": "portable",
         "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "Nancy": "1.4.3",
+        "Nancy.Validation.FluentValidation": "1.4.1"
+    },
+
+    "frameworks": {
+        "netcoreapp1.0": {
+            "dependencies": {
+                "Microsoft.AspNetCore.Hosting": "1.0.0",
+                "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+                "Microsoft.AspNetCore.Owin": "1.0.0",
+                "Microsoft.Extensions.Configuration.Binder":"1.0.0",
+                "Microsoft.Extensions.Configuration.Json":"1.0.0",
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.0.0"
+                }
+            },
+             "imports": [
+                "dotnet54",
+                "portable-net451+win8"
+            ]
+        }
     },
     "tooling": {
         "defaultNamespace": "<%= namespace %>"
-    },
-    "dependencies": {
-        "Microsoft.AspNet.Server.Kestrel": "1.0.0-rc1-final",
-        "Microsoft.AspNet.Owin": "1.0.0-rc1-final",
-        "Nancy": "1.4.3"
-    },
-    "commands": {
-        "web": "Microsoft.AspNet.Server.Kestrel"
-    },
-    "frameworks": {
-        "dnx451": {}
     }
 }

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -29,8 +29,8 @@ describe('Subgenerators without arguments tests', function() {
 
   describe('aspnet:Program in cwd of project.json', function() {
     var dir = util.makeTempDir();
-    // the Nancy project does not contain Program.cs
-    util.goCreateApplication('nancy', 'emptyTest', dir);
+    // the Class Library project does not contain Program.cs
+    util.goCreateApplication('classlibrary', 'emptyTest', dir);
     util.goCreate('Program', path.join(dir, 'emptyTest'));
     util.fileCheck('should create Program.cs file', 'Program.cs');
     util.fileContentCheck('Program.cs', 'file content check', /^namespace emptyTest$/m);

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -851,7 +851,17 @@ describe('aspnet - Nancy Application', function() {
   });
 
 
-  var files = ['nancyTest/project.json', 'nancyTest/Startup.cs', 'nancyTest/HomeModule.cs'];
+  var files = [
+    'nancyTest/AppConfiguration.cs',
+    'nancyTest/appsettings.json',
+    'nancyTest/DemoBootstrapper.cs',
+    'nancyTest/HomeModule.cs',
+    'nancyTest/Person.cs',
+    'nancyTest/PersonValidator.cs',
+    'nancyTest/Program.cs',
+    'nancyTest/project.json',
+    'nancyTest/Startup.cs'
+  ];
   describe('Checking files', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);


### PR DESCRIPTION
This is WIP  - do not merge if not ready. This does not work out-of-the-box using information for RTM:
https://github.com/OmniSharp/generator-aspnet/issues/760

To test this PR locally (after installing update dotnet runtime):
```
- yo aspnet
- cd NancyApplication
- yo aspnet:nuget --unstable
- dotnet restore --no-cache
- dotnet run
```

The original sample baking this project update is available on Nancy reppo:
https://github.com/NancyFx/Nancy/tree/master/samples/Nancy.Demo.Hosting.Kestrel

The project fails to restore dependencies correctly. I could have miss correct packages and deps.
The main blocker can be correct configuration in `project.json`:
https://github.com/peterblazejewicz/generator-aspnet/blob/5a6b663eef9939909c59ad72794ebb36db6e0651/templates/projects/nancy/project.json

/cc
@OmniSharp/generator-aspnet-team-push
@jchannon 

This commit updates Nancy project template for RTM.
Changes:
- project structure is updated for Dotnet core application
structure with Program.cs and Startup.cs
- the content of example is updated and based on Nancy sample:
Nancy.Demo.Hosting.Kestrel: https://git.io/voHvc
- tests have been updated to cover additional content
- tests have been updated to no use Nancy project in other
features tests as after this update the Nancy projet will have
similar structure to ASP.NET Core web projects

Thanks!