### PR TITLE
Remove Nancy project from visible options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Full, template based projects available in generator:
 - Web Application
 - Web Application Basic [without Membership and Authorization]
 - Web API Application
-- Nancy ASP.NET Application
+- Nancy ASP.NET Application (as `yo aspnet nancy {NAME}` command line option)
 - Class Library
 - Unit Test project (xUnit.net)
 
@@ -51,6 +51,7 @@ The Empty Web Application, Console Application, Web Application, Web Application
 
 The Nancy project is based on framework's "Hello World" template:
 [Nancy Getting Started: Introduction](https://github.com/NancyFx/Nancy/wiki/Introduction)
+> We are in the process of updating Nancy template for RTM - until updated the Nancy project type is available only as `yo aspnet nancy {NAME}` command line option
 
 The [Docker](https://www.docker.com/) support with `Dockerfile` configuration files is based on the official [Docker image for ASP.NET 5](https://github.com/aspnet/aspnet-docker)
 

--- a/app/index.js
+++ b/app/index.js
@@ -63,10 +63,10 @@ var AspnetGenerator = yeoman.generators.Base.extend({
           }, {
             name: 'Web API Application',
             value: 'webapi'
-          }, {
+          },/* {
             name: 'Nancy ASP.NET Application',
             value: 'nancy'
-          }, {
+          },*/ {
             name: 'Class Library',
             value: 'classlibrary'
           }, {
@@ -133,9 +133,10 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         case 'webapi':
           app = 'WebAPIApplication';
           break;
+        /*
         case 'nancy':
           app = 'NancyApplication';
-          break;
+          break;*/
         case 'classlibrary':
           app = 'ClassLibrary';
           break;


### PR DESCRIPTION
/cc
@OmniSharp/generator-aspnet-team-push

This commit hides Nancy project template from available
options for end users - while still preserving project
as command line options.
When updated for RTM simply revert this PR completely.

The reasoning behind this PR is that project should provide the same user experience for RTM - including all project templates. As soon as we update Nancy project we should simply revert this commit PR

/cc @sayedihashimi 

Thanks!

Before:
```
? What type of application do you want to create? 
  Empty Web Application 
  Console Application 
  Web Application 
  Web Application Basic [without Membership and Authorization] 
  Web API Application 
❯ Nancy ASP.NET Application 
  Class Library 
  Unit test project (xUnit.net)
```
After:
```
What type of application do you want to create? 
  Empty Web Application 
  Console Application 
  Web Application 
  Web Application Basic [without Membership and Authorization] 
  Web API Application 
  Class Library 
❯ Unit test project (xUnit.net) 
```