### PR TITLE
:white_check_mark: Fix Dockerfile content check tests

### DIFF
--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -109,7 +109,7 @@ describe('Subgenerators without arguments tests', function() {
     util.goCreate(filename);
     util.fileCheck('should create Dockerfile', filename);
     util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:latest/);
-    util.noFileContentCheck(filename, 'Does not contain SQLite install', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+    util.noFileContentCheck(filename, 'Does not contain SQLite install', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     util.noFileContentCheck(filename, 'Does not call database migrations', /RUN \["dotnet", "ef", "database", "update"\]/);
   });
 
@@ -119,7 +119,7 @@ describe('Subgenerators without arguments tests', function() {
     util.goCreateWithArgs(filename, [arg]);
     util.fileCheck('should create Dockerfile', filename);
     util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:latest/);
-    util.fileContentCheck(filename, 'Contains SQLite install', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+    util.fileContentCheck(filename, 'Contains SQLite install', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     util.fileContentCheck(filename, 'Calls database migrations', /RUN \["dotnet", "ef", "database", "update"\]/);
   });
 

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -52,7 +52,7 @@ describe('aspnet - Empty Web Application', function() {
     }
 
     it('Dockerfile does not include SQLite', function() {
-      assert.noFileContent('emptyWebTest/Dockerfile', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+      assert.noFileContent('emptyWebTest/Dockerfile', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     });
 
     it('Dockerfile does not contain migrations', function() {
@@ -300,7 +300,7 @@ describe('aspnet - Web Application (Bootstrap)', function() {
     });
 
     it('Dockerfile includes SQLite', function() {
-      assert.fileContent('webTest/Dockerfile', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+      assert.fileContent('webTest/Dockerfile', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     });
 
     it('Dockerfile contains migrations', function() {
@@ -478,7 +478,7 @@ describe('aspnet - Web Application (Semantic UI)', function() {
     });
 
     it('Dockerfile includes SQLite', function() {
-      assert.fileContent('webTest/Dockerfile', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+      assert.fileContent('webTest/Dockerfile', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     });
 
     it('Dockerfile contains migrations', function() {
@@ -627,7 +627,7 @@ describe('aspnet - Web Application Basic (Bootstrap)', function() {
     });
 
     it('Dockerfile does not include SQLite', function() {
-      assert.noFileContent('webTest/Dockerfile', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+      assert.noFileContent('webTest/Dockerfile', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     });
 
     it('Dockerfile does not contain migrations', function() {
@@ -736,7 +736,7 @@ describe('aspnet - Web Application Basic (Semantic UI)', function() {
     });
 
     it('Dockerfile does not include SQLite', function() {
-      assert.noFileContent('webTest/Dockerfile', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+      assert.noFileContent('webTest/Dockerfile', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     });
 
     it('Dockerfile does not contain migrations', function() {
@@ -825,7 +825,7 @@ describe('aspnet - Web API Application', function() {
     }
 
     it('Dockerfile does not include SQLite', function() {
-      assert.noFileContent('webAPITest/Dockerfile', /RUN apt-get update && apt-get install sqlite3 libsqlite3-dev/);
+      assert.noFileContent('webAPITest/Dockerfile', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     });
 
     it('Dockerfile does not contain migrations', function() {


### PR DESCRIPTION
/cc
@OmniSharp/generator-aspnet-team-push

This commit updates failing tests to cover
change introduced by #787

As side note: the tests can be refactor to less verbose. Their verbosity was required when transitining between DNX RC1/RC2 and RTM with dotnet images.

Thanks!