### PR TITLE
Allow MVC content to be created in the current working directory with sub-generators.

### DIFF
--- a/MvcController/index.js
+++ b/MvcController/index.js
@@ -6,11 +6,6 @@ var path = require('path');
 
 var NamedGenerator = module.exports = function NamedGenerator() {
   ScriptBase.apply(this, arguments);
-
-  // If we're in the root, create the new controller in the Controllers folder
-  if (process.cwd() === path.dirname(cfg.getProjectJsonPath())) {
-    process.chdir(path.join(process.cwd(), 'Controllers'));
-  }
 };
 
 util.inherits(NamedGenerator, ScriptBase);

--- a/MvcView/index.js
+++ b/MvcView/index.js
@@ -6,11 +6,6 @@ var path = require('path');
 
 var NamedGenerator = module.exports = function NamedGenerator() {
   ScriptBase.apply(this, arguments);
-
-  // If we're in the root, create the new view in the Views folder
-  if (process.cwd() === path.dirname(cfg.getProjectJsonPath())) {
-    process.chdir(path.join(process.cwd(), 'Views'));
-  }
 };
 
 util.inherits(NamedGenerator, ScriptBase);

--- a/WebApiController/index.js
+++ b/WebApiController/index.js
@@ -6,11 +6,6 @@ var path = require('path');
 
 var NamedGenerator = module.exports = function NamedGenerator() {
   ScriptBase.apply(this, arguments);
-
-  // If we're in the root, create the new controller in the Controllers folder
-  if (process.cwd() === path.dirname(cfg.getProjectJsonPath())) {
-    process.chdir(path.join(process.cwd(), 'Controllers'));
-  }
 };
 
 util.inherits(NamedGenerator, ScriptBase);


### PR DESCRIPTION
Fixes #757.

Summary of the changes in this PR:
- No longer restricts controller and view subgenerators to only generate objects in their respective folders.
- Fixes exception being thrown when the content folder is not present when creating a WebAPI or MVC controller or MVC view.

Thoughs?

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push

…rs in the current working directory.  Fixes issue #757