### PR TITLE
Revert "Hide Nancy project from visible options"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Full, template based projects available in generator:
 - Web Application
 - Web Application Basic [without Membership and Authorization]
 - Web API Application
-- Nancy ASP.NET Application (as `yo aspnet nancy {NAME}` command line option)
+- Nancy ASP.NET Application
 - Class Library
 - Unit Test project (xUnit.net)
 
@@ -49,7 +49,6 @@ The Empty Web Application, Console Application, Web Application, Web Application
 
 The Nancy project is based on framework's "Hello World" template:
 [Nancy Getting Started: Introduction](https://github.com/NancyFx/Nancy/wiki/Introduction)
-> We are in the process of updating Nancy template for RTM - until updated the Nancy project type is available only as `yo aspnet nancy {NAME}` command line option
 
 The [Docker](https://www.docker.com/) support with `Dockerfile` configuration files is based on the official [Docker image for ASP.NET 5](https://github.com/aspnet/aspnet-docker)
 


### PR DESCRIPTION
This reverts commit d9e563fc716b4757c0344890f1d9dff6a3859cec.
The Nancy project has been already updated to RTM and the change
in README.md was overlooked during Nancy RTM update.

See #794

/cc @jchannon
@OmniSharp/generator-aspnet-team-push
