### PR TITLE
Fixed typo WebApiContoller into WebApiController

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The alphabetic list of available sub generators (_to create files after the proj
 * [aspnet:typescriptconfig](#typescriptconfig)
 * [aspnet:typescriptjsx](#typescriptjsx)
 * [aspnet:usersecrets](#usersecrets)
-* [aspnet:WebApiContoller](#webapicontroller)
+* [aspnet:WebApiController](#webapicontroller)
 
 ** Note: files generated are created in the working directory, no conventions are forced **
 


### PR DESCRIPTION
Fixes TYPO's.

Summary of the changes in this PR:
 - Hard to find the WebApiController generator when searching for Controller instead of Contoller :')

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push
