### PR TITLE
apt-get cleanup in Dockerfile

### DIFF
--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -1,6 +1,6 @@
 FROM microsoft/dotnet:latest
 <% if(sqlite){ %>
-RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev
+RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev && rm -rf /var/lib/apt/lists/*
 <% } %>
 COPY . /app
 

--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -14,4 +14,4 @@ RUN ["dotnet", "ef", "database", "update"]
 <% } %>
 EXPOSE 5000/tcp
 
-ENTRYPOINT ["dotnet", "run", "--server.urls", "http://0.0.0.0:5000"]
+CMD ["dotnet", "run", "--server.urls", "http://0.0.0.0:5000"]


### PR DESCRIPTION
rm -rf /var/lib/apt/lists/* is a best practice found in most Dockerfiles.

https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/
