### PR TITLE
:lock: Apply kb 3181759 fix

### DIFF
--- a/templates/projects/emptyweb/project.json
+++ b/templates/projects/emptyweb/project.json
@@ -6,7 +6,7 @@
     },
     "Microsoft.AspNetCore.Diagnostics": "1.0.0",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
     "Microsoft.Extensions.Logging.Console": "1.0.0",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0",

--- a/templates/projects/nancy/project.json
+++ b/templates/projects/nancy/project.json
@@ -9,7 +9,7 @@
         "netcoreapp1.0": {
             "dependencies": {
                 "Microsoft.AspNetCore.Hosting": "1.0.0",
-                "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+                "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
                 "Microsoft.AspNetCore.Owin": "1.0.0",
                 "Nancy": "2.0.0-barneyrubble",
                 "Microsoft.NETCore.App": {

--- a/templates/projects/web/project.json
+++ b/templates/projects/web/project.json
@@ -10,7 +10,7 @@
     "Microsoft.AspNetCore.Diagnostics": "1.0.0",
     "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.0",
     "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0",
-    "Microsoft.AspNetCore.Mvc": "1.0.0",
+    "Microsoft.AspNetCore.Mvc": "1.0.1",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "1.0.0-preview2-final",
       "type": "build"

--- a/templates/projects/web/project.json
+++ b/templates/projects/web/project.json
@@ -19,7 +19,7 @@
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0",
-    "Microsoft.EntityFrameworkCore.Sqlite": "1.0.0",
+    "Microsoft.EntityFrameworkCore.Sqlite": "1.0.1",
     "Microsoft.EntityFrameworkCore.Sqlite.Design": {
       "version": "1.0.0",
       "type": "build"

--- a/templates/projects/web/project.json
+++ b/templates/projects/web/project.json
@@ -15,8 +15,9 @@
       "version": "1.0.0-preview2-final",
       "type": "build"
     },
+    "Microsoft.AspNetCore.Routing": "1.0.1",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0",
     "Microsoft.EntityFrameworkCore.Sqlite": "1.0.0",
     "Microsoft.EntityFrameworkCore.Sqlite.Design": {

--- a/templates/projects/webapi/project.json
+++ b/templates/projects/webapi/project.json
@@ -4,7 +4,7 @@
       "version": "1.0.0",
       "type": "platform"
     },
-    "Microsoft.AspNetCore.Mvc": "1.0.0",
+    "Microsoft.AspNetCore.Mvc": "1.0.1",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",

--- a/templates/projects/webapi/project.json
+++ b/templates/projects/webapi/project.json
@@ -5,8 +5,9 @@
       "type": "platform"
     },
     "Microsoft.AspNetCore.Mvc": "1.0.1",
+    "Microsoft.AspNetCore.Routing": "1.0.1",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
     "Microsoft.Extensions.Configuration.FileExtensions": "1.0.0",
     "Microsoft.Extensions.Configuration.Json": "1.0.0",

--- a/templates/projects/webbasic/project.json
+++ b/templates/projects/webbasic/project.json
@@ -5,7 +5,7 @@
       "type": "platform"
     },
     "Microsoft.AspNetCore.Diagnostics": "1.0.0",
-    "Microsoft.AspNetCore.Mvc": "1.0.0",
+    "Microsoft.AspNetCore.Mvc": "1.0.1",
     "Microsoft.AspNetCore.Razor.Tools": {
       "version": "1.0.0-preview2-final",
       "type": "build"

--- a/templates/projects/webbasic/project.json
+++ b/templates/projects/webbasic/project.json
@@ -10,8 +10,9 @@
       "version": "1.0.0-preview2-final",
       "type": "build"
     },
+    "Microsoft.AspNetCore.Routing": "1.0.1",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
     "Microsoft.Extensions.Configuration.Json": "1.0.0",


### PR DESCRIPTION
/cc
@OmniSharp/generator-aspnet-team-push

Security update.
Please see:
https://github.com/aspnet/Mvc/issues/5271
https://technet.microsoft.com/en-us/en-us/library/3181759.aspx

The fix is applied to all 3 templates that use any of listed packages. Here is output after fix:
```bash
dotnet restore
log  : Restoring packages for /Users/piotrblazejewicz/development/WebApplication/project.json...
log  : Installing Microsoft.AspNetCore.Mvc.Abstractions 1.0.1.
log  : Installing Microsoft.AspNetCore.Antiforgery 1.0.1.
log  : Installing Microsoft.AspNetCore.Mvc.Core 1.0.1.
log  : Installing Microsoft.AspNetCore.Mvc.Razor.Host 1.0.1.
log  : Installing Microsoft.AspNetCore.Mvc.DataAnnotations 1.0.1.
log  : Installing Microsoft.AspNetCore.Mvc.Cors 1.0.1.
log  : Installing Microsoft.AspNetCore.Mvc.ViewFeatures 1.0.1.
log  : Installing Microsoft.AspNetCore.Mvc.Formatters.Json 1.0.1.
log  : Installing Microsoft.AspNetCore.Mvc.ApiExplorer 1.0.1.
log  : Installing Microsoft.AspNetCore.Mvc.Razor 1.0.1.
log  : Installing Microsoft.AspNetCore.Mvc.Localization 1.0.1.
log  : Installing Microsoft.AspNetCore.Mvc.TagHelpers 1.0.1.
log  : Installing Microsoft.AspNetCore.Mvc 1.0.1.
```

Thanks!