### PR TITLE
Collapse 2 publishOptions include file globbing patterns into 1

### DIFF
--- a/templates/projects/web/project.json
+++ b/templates/projects/web/project.json
@@ -84,8 +84,7 @@
   "publishOptions": {
     "include": [
       "wwwroot",
-      "Views",
-      "Areas/**/Views",
+      "**/*.cshtml",
       "appsettings.json",
       "web.config"
     ]

--- a/templates/projects/webapi/project.json
+++ b/templates/projects/webapi/project.json
@@ -45,8 +45,7 @@
   "publishOptions": {
     "include": [
       "wwwroot",
-      "Views",
-      "Areas/**/Views",
+      "**/*.cshtml",
       "appsettings.json",
       "web.config"
     ]

--- a/templates/projects/webbasic/project.json
+++ b/templates/projects/webbasic/project.json
@@ -53,8 +53,7 @@
   "publishOptions": {
     "include": [
       "wwwroot",
-      "Views",
-      "Areas/**/Views",
+      "**/*.cshtml",
       "appsettings.json",
       "web.config"
     ]


### PR DESCRIPTION
Fixes #815 .

Summary of the changes in this PR:
 - Update the file globbing patterns in the `publishOptions/include` section of `project.json` such that the `Areas/**/Views` and `Views` patterns are replaced with `**/*.cshtml`. This applies to the "web", "webbasic", and "webapi" templates.

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push

