### PR TITLE
Upgrade project templates to .NET Core 1.0.1

### DIFF
--- a/templates/projects/consoleapp/project.json
+++ b/templates/projects/consoleapp/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0"
+      "version": "1.0.1"
     }
   },
 

--- a/templates/projects/emptyweb/project.json
+++ b/templates/projects/emptyweb/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "platform"
     },
     "Microsoft.AspNetCore.Diagnostics": "1.0.0",

--- a/templates/projects/nancy/project.json
+++ b/templates/projects/nancy/project.json
@@ -14,7 +14,7 @@
                 "Nancy": "2.0.0-barneyrubble",
                 "Microsoft.NETCore.App": {
                     "type": "platform",
-                    "version": "1.0.0"
+                    "version": "1.0.1"
                 }
             }
         }

--- a/templates/projects/unittest/project.json
+++ b/templates/projects/unittest/project.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "Microsoft.NETCore.App": {
                     "type": "platform",
-                    "version": "1.0.0"
+                    "version": "1.0.1"
                 }
             }
         }

--- a/templates/projects/web/project.json
+++ b/templates/projects/web/project.json
@@ -3,7 +3,7 @@
 
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "platform"
     },
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",

--- a/templates/projects/webapi/project.json
+++ b/templates/projects/webapi/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "platform"
     },
     "Microsoft.AspNetCore.Mvc": "1.0.1",

--- a/templates/projects/webbasic/project.json
+++ b/templates/projects/webbasic/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "platform"
     },
     "Microsoft.AspNetCore.Diagnostics": "1.0.0",


### PR DESCRIPTION
Fixes #817 .

Summary of the changes in this PR:
 - Update each project template's `project.json` file to explicitly target .NET Core 1.0.1 within the `dependencies` section.

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push

