### PR TITLE
Fix minor mistakes in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ The Empty Web Application, Console Application, Web Application, Web Application
 The Nancy project is based on framework's "Hello World" template:
 [Nancy Getting Started: Introduction](https://github.com/NancyFx/Nancy/wiki/Introduction)
 
-The [Docker](https://www.docker.com/) support with `Dockerfile` configuration files is based on the official [Docker image for ASP.NET 5](https://github.com/aspnet/aspnet-docker)
+The [Docker](https://www.docker.com/) support with `Dockerfile` configuration files is based on the official [Docker image for ASP.NET Core](https://github.com/aspnet/aspnet-docker)
 
 The Unit test project uses [xUnit: a free, open source, community-focused unit testing tool for the .NET Framework](https://xunit.github.io/)
 
-The templates that use client side libraries are calling `bower install` script to install Bower managed dependencies. You can skip installation process by passign `--skip-install` option to generator, e.g. `yo aspnet --skip-install`. This should allow better experience when `Development` has been enabled.
+The templates that use client-side libraries are calling the `bower install` script to install Bower managed dependencies. You can skip the installation process by passing the `--skip-install` option to the generator, e.g. `yo aspnet --skip-install`. This should allow for a better experience when `Development` has been enabled.
 
 ## Command line automation
 


### PR DESCRIPTION
Summary of the changes in this PR:
 - Update Docker image "ASP.NET 5" text to reference "ASP.NET Core"
 - Fix spelling mistake of word "passing"
 - Add missing words to make Bower installation paragraph a bit clearer

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push

