### PR TITLE
Ignore .jfm files in Visual Studio. Closes #826

### DIFF
--- a/templates/gitignore.txt
+++ b/templates/gitignore.txt
@@ -179,6 +179,7 @@ ClientBin/
 *~
 *.dbmdl
 *.dbproj.schemaview
+*.jfm
 *.pfx
 *.publishsettings
 node_modules/

--- a/templates/projects/fsharp_webapi/.gitignore
+++ b/templates/projects/fsharp_webapi/.gitignore
@@ -179,6 +179,7 @@ ClientBin/
 *~
 *.dbmdl
 *.dbproj.schemaview
+*.jfm
 *.pfx
 *.publishsettings
 node_modules/

--- a/templates/projects/fsharp_webbasic/.gitignore
+++ b/templates/projects/fsharp_webbasic/.gitignore
@@ -179,6 +179,7 @@ ClientBin/
 *~
 *.dbmdl
 *.dbproj.schemaview
+*.jfm
 *.pfx
 *.publishsettings
 node_modules/

--- a/templates/tfignore.txt
+++ b/templates/tfignore.txt
@@ -167,6 +167,7 @@ ClientBin/
 *~
 *.dbmdl
 *.dbproj.schemaview
+*.jfm
 *.pfx
 *.publishsettings
 node_modules/


### PR DESCRIPTION
This commit introduce ignore rule for .jfm files
which is already a rule in source project for .gitignore
files for VS related configuration.
For details please see:
@github/gitignore#2104

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push
