### PR TITLE
fixed misname of ConfigureServices

### DIFF
--- a/templates/projects/fsharp_emptyweb/Startup.fs
+++ b/templates/projects/fsharp_emptyweb/Startup.fs
@@ -12,7 +12,7 @@ type Startup() =
 
     /// This method gets called by the runtime. Use this method to add services to the container.
     /// For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
-    member this.ConfigureService(services:IServiceCollection) = ()
+    member this.ConfigureServices(services:IServiceCollection) = ()
     
 
     /// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION


Summary of the changes in this PR:
 - ConfigureServices was mistyped in the fsharp  empty_web template
  proper name is defined here: https://docs.asp.net/en/latest/intro.html#startup

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push

