### PR TITLE
add the escape character for  “Template projects"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Full, template based projects available in generator:
 - Console Application (F#)
 - Web Application
 - Web Application Basic [without Membership and Authorization]
-- Web Application Basic [without Membership and Authorization] (F#)
+- Web Application Basic [without Membership and Authorization] \(F#)
 - Web API Application
 - Web API Application (F#)
 - Nancy ASP.NET Application


### PR DESCRIPTION
add the escape character.
before:
<img width="527" src="https://cloud.githubusercontent.com/assets/5362201/20292952/d20a383a-ab2c-11e6-9294-5af79a957bce.png">
after:
<img width="559" src="https://cloud.githubusercontent.com/assets/5362201/20292975/01d79f9e-ab2d-11e6-8daa-07fda7d19540.png">
