### PR TITLE
Upgrading web project framework to netcoreapp1.1

### DIFF
--- a/templates/projects/web/project.json
+++ b/templates/projects/web/project.json
@@ -62,7 +62,7 @@
   },
 
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.6",
         "portable-net45+win8"


### PR DESCRIPTION
Fixes #837 #847.

Summary of the changes in this PR:
 - Upgraded web project template framework to .NET Core 1.1.0
 - The dependency was updated in #847 but not the framework. This causes the app to still publish as v1.0

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push

