### PR TITLE
Update Travis CI build Node and NPM versions. Closes #852

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 sudo: false
 language: node_js
 node_js:
-- '0.10'
+- '4'
 before_install:
-  npm install -g npm@'>=2.13.5'
+  - if [[ `npm -v` != 3* ]];
+    then npm i -g npm@3;
+    fi
 deploy:
   provider: npm
   email: sayed.hashimi@gmail.com


### PR DESCRIPTION
First see #852 and [this comment](https://github.com/OmniSharp/generator-aspnet/pull/848#issuecomment-264217630)

This commit updates Node version to latest version of 4 LTS build
and to NPM 3 version.
This change is added to avoid situation of failing build scripts due to
NPM warnings or errors about Node v. 0.10 unsupported version.

The version 4.* LTS is one that Mocha scripts are passing without NPM
dependencies updates and major rewrites.
The Node 4.* version support on Travis would allow to use Yarn as
package manager client for NPM packages which could significantly
reduce time taken by single Travis CI builds

Note that this change does not change the package.json Node JS support
requirement yet

@sayedihashimi 
Up to you. This is just technical issue with Travis CI builds.

/cc
@OmniSharp/generator-aspnet-team-push
