### PR TITLE
Use explicit version tag in Dockerfile

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -228,6 +228,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.copy(this.sourceRoot() + '/web.config', this.applicationName + '/web.config');
 
         this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile', this.templatedata);
+        this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.nano.txt', this.applicationName + '/Dockerfile.nano', this.templatedata);
 
         /// Properties
         this.fs.copyTpl(this.templatePath('Properties/**/*'), this.applicationName + '/Properties', this.templatedata);
@@ -240,6 +241,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.fs.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '/.gitignore');
         this.copy(this.sourceRoot() + '/appsettings.json', this.applicationName + '/appsettings.json');
         this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile', this.templatedata);
+        this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.nano.txt', this.applicationName + '/Dockerfile.nano', this.templatedata);
         this.fs.copyTpl(this.sourceRoot() + '/Startup.cs', this.applicationName + '/Startup.cs', this.templatedata);
         this.fs.copyTpl(this.sourceRoot() + '/Program.cs', this.applicationName + '/Program.cs', this.templatedata);
         this.fs.copyTpl(this.sourceRoot() + '/project.json', this.applicationName + '/project.json', this.templatedata);
@@ -254,6 +256,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
         // individual files (configs, etc)
         this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile', this.templatedata);
+        this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.nano.txt', this.applicationName + '/Dockerfile.nano', this.templatedata);
         this.fs.copy(this.templatePath('.bowerrc'), this.applicationName + '/.bowerrc');
         this.fs.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '/.gitignore');
         this.fs.copyTpl(this.templatePath('appsettings.json'), this.applicationName + '/appsettings.json', this.templatedata);
@@ -298,6 +301,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
         // individual files (configs, etc)
         this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile', this.templatedata);
+        this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.nano.txt', this.applicationName + '/Dockerfile.nano', this.templatedata);
         this.fs.copy(this.templatePath('.bowerrc'), this.applicationName + '/.bowerrc');
         this.fs.copy(this.templatePath('bundleconfig.json'), this.applicationName + '/bundleconfig.json');
         this.fs.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '/.gitignore');
@@ -390,6 +394,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.copy(this.sourceRoot() + '/web.config', this.applicationName + '/web.config');
 
         this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile', this.templatedata);
+        this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.nano.txt', this.applicationName + '/Dockerfile.nano', this.templatedata);
 
         /// Properties
         this.fs.copyTpl(this.templatePath('Properties/**/*'), this.applicationName + '/Properties', this.templatedata);
@@ -402,6 +407,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.fs.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '/.gitignore');
         this.copy(this.sourceRoot() + '/appsettings.json', this.applicationName + '/appsettings.json');
         this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile', this.templatedata);
+        this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.nano.txt', this.applicationName + '/Dockerfile.nano', this.templatedata);
         this.fs.copyTpl(this.sourceRoot() + '/Startup.fs', this.applicationName + '/Startup.fs', this.templatedata);
         this.fs.copyTpl(this.sourceRoot() + '/Program.fs', this.applicationName + '/Program.fs', this.templatedata);
         this.fs.copyTpl(this.sourceRoot() + '/project.json', this.applicationName + '/project.json', this.templatedata);
@@ -416,6 +422,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
         // individual files (configs, etc)
         this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.txt', this.applicationName + '/Dockerfile', this.templatedata);
+        this.fs.copyTpl(this.sourceRoot() + '/../../Dockerfile.nano.txt', this.applicationName + '/Dockerfile.nano', this.templatedata);
         this.fs.copy(this.templatePath('.bowerrc'), this.applicationName + '/.bowerrc');
         this.fs.copy(this.templatePath('bundleconfig.json'), this.applicationName + '/bundleconfig.json');
         this.fs.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '/.gitignore');

--- a/templates/Dockerfile.nano.txt
+++ b/templates/Dockerfile.nano.txt
@@ -1,0 +1,15 @@
+FROM microsoft/dotnet:1.1.0-sdk-projectjson-nanoserver
+
+COPY . /app
+
+WORKDIR /app
+
+RUN ["dotnet", "restore"]
+
+RUN ["dotnet", "build"]
+<% if(sqlite){ %>
+RUN ["dotnet", "ef", "database", "update"]
+<% } %>
+EXPOSE 5000/tcp
+
+CMD ["dotnet", "run", "--server.urls", "http://*:5000"]

--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:dotnet:1.1.0-sdk-projectjson
+FROM microsoft/dotnet:1.1.0-sdk-projectjson
 <% if(sqlite){ %>
 RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev && rm -rf /var/lib/apt/lists/*
 <% } %>

--- a/templates/Dockerfile.txt
+++ b/templates/Dockerfile.txt
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:latest
+FROM microsoft/dotnet:dotnet:1.1.0-sdk-projectjson
 <% if(sqlite){ %>
 RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev && rm -rf /var/lib/apt/lists/*
 <% } %>

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -90,6 +90,18 @@ describe('Subgenerators without arguments tests', function() {
     util.fileCheck('should create tsconfig.json file', 'tsconfig.json');
   });
 
+  describe('aspnet:dockerfile has the same .NET version', function() {
+    var sdkVersion = '1.1.0';
+    var arg = 'file';
+    var dir = util.makeTempDir();
+
+    util.goCreateApplication('web', 'webTest', dir);
+    util.goCreateWithArgs('mvccontroller', [arg], path.join(dir, 'webTest'));
+
+    util.fileContentCheck('project.json', 'file content check', new RegExp(`"Microsoft.NETCore.App":\\s*{\\s*"version": "${sdkVersion}"`));
+    util.fileContentCheck('Dockerfile', 'Check the content for dotnet latest image tag', new RegExp(`FROM microsoft\/dotnet:dotnet:${sdkVersion}-sdk-projectjson`));
+  });
+
   /**
    * Dockerfile can be created with two versions:
    * - without SQLite installed
@@ -99,7 +111,7 @@ describe('Subgenerators without arguments tests', function() {
     var filename = 'Dockerfile';
     util.goCreate(filename.toLowerCase());
     util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:dotnet:1.1.0-sdk-projectjson/);
+    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:dotnet:/);
     util.noFileContentCheck(filename, 'Does not contain SQLite install', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     util.noFileContentCheck(filename, 'Does not call database migrations', /RUN \["dotnet", "ef", "database", "update"\]/);
   });
@@ -109,7 +121,7 @@ describe('Subgenerators without arguments tests', function() {
     var filename = 'Dockerfile';
     util.goCreateWithArgs(filename.toLowerCase(), [arg]);
     util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:dotnet:1.1.0-sdk-projectjson/);
+    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:dotnet:/);
     util.fileContentCheck(filename, 'Contains SQLite install', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     util.fileContentCheck(filename, 'Calls database migrations', /RUN \["dotnet", "ef", "database", "update"\]/);
   });

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -98,8 +98,8 @@ describe('Subgenerators without arguments tests', function() {
     util.goCreateApplication('web', 'webTest', dir);
     util.goCreateWithArgs('mvccontroller', [arg], path.join(dir, 'webTest'));
 
-    util.fileContentCheck('project.json', 'file content check', new RegExp(`"Microsoft.NETCore.App":\\s*{\\s*"version": "${sdkVersion}"`));
-    util.fileContentCheck('Dockerfile', 'Check the content for dotnet latest image tag', new RegExp(`FROM microsoft\/dotnet:dotnet:${sdkVersion}-sdk-projectjson`));
+    util.fileContentCheck('project.json', 'file content check', new RegExp('"Microsoft.NETCore.App":\\s*{\\s*"version": "' + sdkVersion + '"'));
+    util.fileContentCheck('Dockerfile', 'Check the content for dotnet latest image tag', new RegExp('FROM microsoft\/dotnet:dotnet:' + sdkVersion + '-sdk-projectjson'));
   });
 
   /**

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -99,7 +99,7 @@ describe('Subgenerators without arguments tests', function() {
     util.goCreateWithArgs('mvccontroller', [arg], path.join(dir, 'webTest'));
 
     util.fileContentCheck('project.json', 'file content check', new RegExp('"Microsoft.NETCore.App":\\s*{\\s*"version": "' + sdkVersion + '"'));
-    util.fileContentCheck('Dockerfile', 'Check the content for dotnet latest image tag', new RegExp('FROM microsoft\/dotnet:dotnet:' + sdkVersion + '-sdk-projectjson'));
+    util.fileContentCheck('Dockerfile', 'Check the content for dotnet latest image tag', new RegExp('FROM microsoft\/dotnet:' + sdkVersion + '-sdk-projectjson'));
   });
 
   /**
@@ -111,7 +111,7 @@ describe('Subgenerators without arguments tests', function() {
     var filename = 'Dockerfile';
     util.goCreate(filename.toLowerCase());
     util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:dotnet:/);
+    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:/);
     util.noFileContentCheck(filename, 'Does not contain SQLite install', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     util.noFileContentCheck(filename, 'Does not call database migrations', /RUN \["dotnet", "ef", "database", "update"\]/);
   });
@@ -121,7 +121,7 @@ describe('Subgenerators without arguments tests', function() {
     var filename = 'Dockerfile';
     util.goCreateWithArgs(filename.toLowerCase(), [arg]);
     util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:dotnet:/);
+    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:/);
     util.fileContentCheck(filename, 'Contains SQLite install', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     util.fileContentCheck(filename, 'Calls database migrations', /RUN \["dotnet", "ef", "database", "update"\]/);
   });

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -99,7 +99,8 @@ describe('Subgenerators without arguments tests', function() {
     util.goCreateWithArgs('mvccontroller', [arg], path.join(dir, 'webTest'));
 
     util.fileContentCheck('project.json', 'file content check', new RegExp('"Microsoft.NETCore.App":\\s*{\\s*"version": "' + sdkVersion + '"'));
-    util.fileContentCheck('Dockerfile', 'Check the content for dotnet latest image tag', new RegExp('FROM microsoft\/dotnet:' + sdkVersion + '-sdk-projectjson'));
+    util.fileContentCheck('Dockerfile', 'Check the content for dotnet latest image tag', new RegExp('FROM microsoft\/dotnet:' + sdkVersion + '-sdk-projectjson\\b'));
+    util.fileContentCheck('Dockerfile.nano', 'Check the content for dotnet nanoserver latest image tag', new RegExp('FROM microsoft\/dotnet:' + sdkVersion + '-sdk-projectjson-nanoserver\\b'));
   });
 
   /**

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -99,7 +99,7 @@ describe('Subgenerators without arguments tests', function() {
     var filename = 'Dockerfile';
     util.goCreate(filename.toLowerCase());
     util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:latest/);
+    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:dotnet:1.1.0-sdk-projectjson/);
     util.noFileContentCheck(filename, 'Does not contain SQLite install', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     util.noFileContentCheck(filename, 'Does not call database migrations', /RUN \["dotnet", "ef", "database", "update"\]/);
   });
@@ -109,7 +109,7 @@ describe('Subgenerators without arguments tests', function() {
     var filename = 'Dockerfile';
     util.goCreateWithArgs(filename.toLowerCase(), [arg]);
     util.fileCheck('should create Dockerfile', filename);
-    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:latest/);
+    util.fileContentCheck(filename, 'Check the content for dotnet latest image tag', /FROM microsoft\/dotnet:dotnet:1.1.0-sdk-projectjson/);
     util.fileContentCheck(filename, 'Contains SQLite install', /RUN apt-get update && apt-get install -y sqlite3 libsqlite3-dev/);
     util.fileContentCheck(filename, 'Calls database migrations', /RUN \["dotnet", "ef", "database", "update"\]/);
   });


### PR DESCRIPTION
Fixes #851.

Summary of the changes in this PR:
 - Use an explicit CLR version tag in the Dockerfile
 - Make sure the CLR version used in the project.json and Dockerfile match

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push
