### PR TITLE
:bug: Catch null results correctly. Fixes 855

### DIFF
--- a/configuration.js
+++ b/configuration.js
@@ -32,7 +32,7 @@ module.exports = {
 
     var baseNamespace = getBaseNamespace(fs);
     var cwd = process.cwd();
-    var baseDirectory = path.resolve(path.dirname(this.getProjectJsonPath()));
+    var baseDirectory = path.resolve(path.dirname(this.getProjectJsonPath() || ''));
     var relativePath = path.relative(baseDirectory, cwd);
     if (relativePath) {
       return [baseNamespace].concat(relativePath.split(path.sep)).join('.');


### PR DESCRIPTION
Fixes #855

/cc
@OmniSharp/generator-aspnet-team-push

This commit fixes small coding problem when results from a method are not checked
for possible null. The fix is to just safely provide empty string

Thanks!