### PR TITLE
Add Node version configuration file to the project

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,6 +4,17 @@
 
 One of the easiest ways to contribute is to participate in discussions and discuss issues. You can also contribute by submitting pull requests with code changes. Just [follow rules used in Open Source projects on GitHub.com](https://guides.github.com/activities/contributing-to-open-source/).
 
+## A note about Node version supports in development
+
+The current version of development tools has been created and tested with Node 4 and NPM 3. When updating content of this project please make use of [NVM](https://github.com/creationix/nvm) Node version manager. The project root contains `.nvmrc` confiugration file to support multiple version of Nodes:
+
+```bash
+nvm use
+Found '/Users/piotrblazejewicz/git/generator-aspnet/.nvmrc' with version <lts/argon>
+```
+
+The project goes is to move tooling support into Node 6 before current LTS support ends.
+
 ## How to contribute
 Follow the steps below.
 

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/argon


### PR DESCRIPTION
This will help to maintain tooling migration from current Node LTS
version (4.*) to Node 6.
When developing for the project make sure you call `nvm use` from
console in order to set supported version of Node.

The contributing doc has been updated to reflect this addition

What is the `LTS` in Node:
https://nodejs.org/en/blog/release/v4.2.0/

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push
