### PR TITLE
:art: Always create `global.json` at the project root. Closes #836

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -144,6 +144,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
     this.templatedata.guid = guid.v4();
     this.templatedata.sqlite = (this.type === 'web') ? true : false;
     this.templatedata.ui = this.ui;
+    this.templatedata.version = "1.0.0-preview2-1-003177";
   },
 
   askForName: function() {
@@ -234,6 +235,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.fs.copyTpl(this.templatePath('Properties/**/*'), this.applicationName + '/Properties', this.templatedata);
         this.fs.copy(this.sourceRoot() + '/README.md', this.applicationName + '/README.md');
         mkdirp.sync(this.applicationName + '/wwwroot');
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
 
       case 'webapi':
@@ -250,6 +252,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.fs.copy(this.sourceRoot() + '/web.config', this.applicationName + '/web.config');
         this.fs.copy(this.sourceRoot() + '/README.md', this.applicationName + '/README.md');
         mkdirp.sync(this.applicationName + '/wwwroot');
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
 
       case 'web':
@@ -295,7 +298,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         // UI Component Overrides
         // If the developer has placed anything in overrides/ui-module/project-type/**/* then use it
         this.fs.copyTpl(this.templatePath('/../../overrides/' + this.ui + '/' + this.type + '/**/*'), this.applicationName + '/', this.templatedata);
-
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
       case 'webbasic':
         this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
@@ -326,7 +329,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         // UI Component Overrides
         // If the developer has placed anything in overrides/ui-module/project-type/**/* then use it
         this.fs.copyTpl(this.templatePath('/../../overrides/' + this.ui + '/' + this.type + '/**/*'), this.applicationName + '/', this.templatedata);
-
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
       case 'nancy':
         this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
@@ -340,14 +343,14 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.template(this.sourceRoot() + '/HomeModule.cs', this.applicationName + '/HomeModule.cs', this.templatedata);
 
         this.template(this.sourceRoot() + '/Program.cs', this.applicationName + '/Program.cs', this.templatedata);
-
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
       case 'consoleapp':
         this.sourceRoot(path.join(__dirname, '../templates/projects/consoleapp'));
         this.fs.copy(path.join(__dirname, '../templates/gitignore.txt'), this.applicationName + '/.gitignore');
         this.fs.copyTpl(this.templatePath('Program.cs'), this.applicationName + '/Program.cs', this.templatedata);
         this.fs.copyTpl(this.templatePath('project.json'), this.applicationName + '/project.json', this.templatedata);
-
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
       case 'classlibrary':
         this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
@@ -357,12 +360,13 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.template(this.sourceRoot() + '/class.cs', this.applicationName + '/Class1.cs', this.templatedata);
 
         this.fs.copyTpl(this.sourceRoot() + '/project.json', this.applicationName + '/project.json', this.templatedata);
-
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
       case 'unittest':
         this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
         this.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '/.gitignore');
         this.fs.copyTpl(this.templatePath('**.*'), this.destinationPath(this.applicationName), this.templatedata);
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
 
       //F# Cases
@@ -371,6 +375,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '/.gitignore');
         this.template(this.sourceRoot() + '/Library.fs', this.applicationName + '/Library.fs', this.templatedata);
         this.fs.copyTpl(this.sourceRoot() + '/project.json', this.applicationName + '/project.json', this.templatedata);
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
 
       case 'fsharp_console':
@@ -378,6 +383,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.fs.copy(path.join(__dirname, '../templates/gitignore.txt'), this.applicationName + '/.gitignore');
         this.fs.copyTpl(this.templatePath('Program.fs'), this.applicationName + '/Program.fs', this.templatedata);
         this.fs.copyTpl(this.templatePath('project.json'), this.applicationName + '/project.json', this.templatedata);
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
 
       case 'fsharp_emptyweb':
@@ -400,6 +406,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.fs.copyTpl(this.templatePath('Properties/**/*'), this.applicationName + '/Properties', this.templatedata);
         this.fs.copy(this.sourceRoot() + '/README.md', this.applicationName + '/README.md');
         mkdirp.sync(this.applicationName + '/wwwroot');
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
       
       case 'fsharp_webapi':
@@ -416,6 +423,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         this.fs.copy(this.sourceRoot() + '/web.config', this.applicationName + '/web.config');
         this.fs.copy(this.sourceRoot() + '/README.md', this.applicationName + '/README.md');
         mkdirp.sync(this.applicationName + '/wwwroot');
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
 
       case 'fsharp_webbasic':
@@ -443,12 +451,14 @@ var AspnetGenerator = yeoman.generators.Base.extend({
         // wwwroot - the content in the wwwroot does not include any direct references or imports
         // So again it is copied 1-to-1 - but tests cover list of all files
         this.fs.copy(this.templatePath('wwwroot/**/*'), this.applicationName + '/wwwroot');
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
 
       case 'fsharp_test':
         this.sourceRoot(path.join(__dirname, '../templates/projects/' + this.type));
         this.copy(this.sourceRoot() + '/../../gitignore.txt', this.applicationName + '/.gitignore');
         this.fs.copyTpl(this.templatePath('**.*'), this.destinationPath(this.applicationName), this.templatedata);
+        this.template(this.sourceRoot() + '/../../global.json', this.applicationName + '/global.json', this.templatedata);
         break;
 
       default:

--- a/templates/global.json
+++ b/templates/global.json
@@ -1,0 +1,5 @@
+{
+  "sdk": {
+    "version": "<%= version %>"
+  }
+}

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -39,6 +39,7 @@ describe('aspnet - Empty Web Application', function() {
 
   var files = [
     'emptyWebTest/.gitignore',
+    'emptyWebTest/global.json',
     'emptyWebTest/project.json',
     'emptyWebTest/Program.cs',
     'emptyWebTest/Properties/launchSettings.json',
@@ -60,6 +61,10 @@ describe('aspnet - Empty Web Application', function() {
       assert.noFileContent('emptyWebTest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
     });
 
+    it('global.json contains correct version', function() {
+      assert.fileContent('emptyWebTest/global.json', /1.0.0-preview2-1-003177/);
+    });
+
   });
 
 });
@@ -77,11 +82,16 @@ describe('aspnet - Class Library', function() {
     });
   });
 
-  var files = ['classLibraryTest/project.json', 'classLibraryTest/Class1.cs', 'classLibraryTest/.gitignore'];
+  var files = ['classLibraryTest/global.json', 'classLibraryTest/project.json', 'classLibraryTest/Class1.cs', 'classLibraryTest/.gitignore'];
   describe('Checking files', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+
+    it('global.json contains correct version', function() {
+      assert.fileContent('classLibraryTest/global.json', /1.0.0-preview2-1-003177/);
+    });
+
   });
 
 });
@@ -103,12 +113,18 @@ describe('aspnet - Console Application', function() {
   var files = [
     'consoleAppTest/.gitignore',
     'consoleAppTest/Program.cs',
+    'consoleAppTest/global.json',
     'consoleAppTest/project.json'
   ];
   describe('Checking files', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+
+    it('global.json contains correct version', function() {
+      assert.fileContent('consoleAppTest/global.json', /1.0.0-preview2-1-003177/);
+    });
+
   });
 
 });
@@ -128,6 +144,7 @@ describe('aspnet - Unit Test Application', function() {
 
   var files = [
     'unittestTest/.gitignore',
+    'unittestTest/global.json',
     'unittestTest/project.json',
     'unittestTest/Class1.cs',
     'unittestTest/xunit.runner.json'
@@ -136,6 +153,11 @@ describe('aspnet - Unit Test Application', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+
+    it('global.json contains correct version', function() {
+      assert.fileContent('unittestTest/global.json', /1.0.0-preview2-1-003177/);
+    });
+
   });
 
 });
@@ -224,6 +246,7 @@ describe('aspnet - Web Application (Bootstrap)', function() {
     'webTest/bundleconfig.json',
     'webTest/Dockerfile',
     'webTest/Program.cs',
+    'webTest/global.json',
     'webTest/project.json',
     'webTest/README.md',
     'webTest/Startup.cs',
@@ -306,6 +329,10 @@ describe('aspnet - Web Application (Bootstrap)', function() {
 
     it('Dockerfile contains migrations', function() {
       assert.fileContent('webTest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
+    });
+
+    it('global.json contains correct version', function() {
+      assert.fileContent('webTest/global.json', /1.0.0-preview2-1-003177/);
     });
 
   });
@@ -400,6 +427,7 @@ describe('aspnet - Web Application (Semantic UI)', function() {
     'webTest/bundleconfig.json',
     'webTest/Dockerfile',
     'webTest/Program.cs',
+    'webTest/global.json',
     'webTest/project.json',
     'webTest/README.md',
     'webTest/Startup.cs',
@@ -484,6 +512,10 @@ describe('aspnet - Web Application (Semantic UI)', function() {
 
     it('Dockerfile contains migrations', function() {
       assert.fileContent('webTest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
+    });
+
+    it('global.json contains correct version', function() {
+      assert.fileContent('webTest/global.json', /1.0.0-preview2-1-003177/);
     });
 
   });
@@ -702,6 +734,7 @@ describe('aspnet - Web Application Basic (Semantic UI)', function() {
     'webTest/appsettings.json',
     'webTest/Controllers/HomeController.cs',
     'webTest/Program.cs',
+    'webTest/global.json',
     'webTest/project.json',
     'webTest/Properties/launchSettings.json',
     'webTest/README.md',
@@ -742,6 +775,10 @@ describe('aspnet - Web Application Basic (Semantic UI)', function() {
 
     it('Dockerfile does not contain migrations', function() {
       assert.noFileContent('webTest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
+    });
+
+    it('global.json contains correct version', function() {
+      assert.fileContent('webTest/global.json', /1.0.0-preview2-1-003177/);
     });
 
   });
@@ -811,6 +848,7 @@ describe('aspnet - Web API Application', function() {
   var files = [
     'webAPITest/Controllers/ValuesController.cs',
     'webAPITest/appsettings.json',
+    'webAPITest/global.json',
     'webAPITest/project.json',
     'webAPITest/Program.cs',
     'webAPITest/Properties/launchSettings.json',
@@ -833,6 +871,10 @@ describe('aspnet - Web API Application', function() {
       assert.noFileContent('webAPITest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
     });
 
+    it('global.json contains correct version', function() {
+      assert.fileContent('webAPITest/global.json', /1.0.0-preview2-1-003177/);
+    });
+
   });
 
 });
@@ -852,11 +894,16 @@ describe('aspnet - Nancy Application', function() {
   });
 
 
-  var files = ['nancyTest/project.json', 'nancyTest/Startup.cs', 'nancyTest/HomeModule.cs', 'nancyTest/Program.cs', 'nancyTest/.gitignore'];
+  var files = ['nancyTest/global.json', 'nancyTest/project.json', 'nancyTest/Startup.cs', 'nancyTest/HomeModule.cs', 'nancyTest/Program.cs', 'nancyTest/.gitignore'];
   describe('Checking files', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+
+    it('global.json contains correct version', function() {
+      assert.fileContent('nancyTest/global.json', /1.0.0-preview2-1-003177/);
+    });
+
   });
 
 });
@@ -875,11 +922,16 @@ describe('FSharp Class Library', function() {
     });
   });
 
-  var files = ['fsharpLibTest/project.json', 'fsharpLibTest/Library.fs', 'fsharpLibTest/.gitignore'];
+  var files = ['fsharpLibTest/global.json', 'fsharpLibTest/project.json', 'fsharpLibTest/Library.fs', 'fsharpLibTest/.gitignore'];
   describe('Checking files', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+
+    it('global.json contains correct version', function() {
+      assert.fileContent('fsharpLibTest/global.json', /1.0.0-preview2-1-003177/);
+    });
+
   });
 
 });
@@ -901,12 +953,18 @@ describe('FSharp Console Application', function() {
   var files = [
     'fsharpConsoleTest/.gitignore',
     'fsharpConsoleTest/Program.fs',
+    'fsharpConsoleTest/global.json',
     'fsharpConsoleTest/project.json'
   ];
   describe('Checking files', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+
+    it('global.json contains correct version', function() {
+      assert.fileContent('fsharpConsoleTest/global.json', /1.0.0-preview2-1-003177/);
+    });
+
   });
 });
 
@@ -925,6 +983,7 @@ describe('aspnet - Fsharp Unit Test Application', function() {
 
   var files = [
     'fsharpTestTest/.gitignore',
+    'fsharpTestTest/global.json',
     'fsharpTestTest/project.json',
     'fsharpTestTest/UnitTest1.fs',
     'fsharpTestTest/xunit.runner.json'
@@ -933,6 +992,11 @@ describe('aspnet - Fsharp Unit Test Application', function() {
     for (var i = 0; i < files.length; i++) {
       util.filesCheck(files[i]);
     }
+
+    it('global.json contains correct version', function() {
+      assert.fileContent('fsharpTestTest/global.json', /1.0.0-preview2-1-003177/);
+    });
+
   });
 });
 
@@ -962,6 +1026,7 @@ describe('aspnet - F# Empty Web Application', function() {
 
   var files = [
     'fsharpEmptyWebTest/.gitignore',
+    'fsharpEmptyWebTest/global.json',
     'fsharpEmptyWebTest/project.json',
     'fsharpEmptyWebTest/Program.fs',
     'fsharpEmptyWebTest/Properties/launchSettings.json',
@@ -981,6 +1046,10 @@ describe('aspnet - F# Empty Web Application', function() {
 
     it('Dockerfile does not contain migrations', function() {
       assert.noFileContent('fsharpEmptyWebTest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
+    });
+
+    it('global.json contains correct version', function() {
+      assert.fileContent('fsharpEmptyWebTest/global.json', /1.0.0-preview2-1-003177/);
     });
 
   });
@@ -1013,6 +1082,7 @@ describe('aspnet - Fsharp Web API Application', function() {
   var files = [
     'fsharpWebAPITest/Controllers.fs',
     'fsharpWebAPITest/appsettings.json',
+    'fsharpWebAPITest/global.json',
     'fsharpWebAPITest/project.json',
     'fsharpWebAPITest/Program.fs',
     'fsharpWebAPITest/Properties/launchSettings.json',
@@ -1033,6 +1103,10 @@ describe('aspnet - Fsharp Web API Application', function() {
 
     it('Dockerfile does not contain migrations', function() {
       assert.noFileContent('fsharpWebAPITest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
+    });
+
+    it('global.json contains correct version', function() {
+      assert.fileContent('fsharpWebAPITest/global.json', /1.0.0-preview2-1-003177/);
     });
 
   });
@@ -1095,6 +1169,7 @@ describe('aspnet - FSharp Web Application Basic', function() {
     'fsharpWebBasicTest/appsettings.json',
     'fsharpWebBasicTest/Controllers.fs',
     'fsharpWebBasicTest/Program.fs',
+    'fsharpWebBasicTest/global.json',
     'fsharpWebBasicTest/project.json',
     'fsharpWebBasicTest/Properties/launchSettings.json',
     'fsharpWebBasicTest/README.md',
@@ -1132,6 +1207,10 @@ describe('aspnet - FSharp Web Application Basic', function() {
 
     it('Dockerfile does not contain migrations', function() {
       assert.noFileContent('fsharpWebBasicTest/Dockerfile', /RUN \["dotnet", "ef", "database", "update"\]/);
+    });
+
+    it('global.json contains correct version', function() {
+      assert.fileContent('fsharpWebBasicTest/global.json', /1.0.0-preview2-1-003177/);
     });
 
   });


### PR DESCRIPTION
The purpose of this commit is to patch problems users encountered when pushing content created with this generated to Azure.

:art: Add global.json template file

This adds only template file that will be used by content creation
scripts. The content of *version* key will be set according to
dynamic variables constructed on the generator run

:white_check_mark: Test coverage for global.json

This adds tests for all cases when global.json is created
by main generator. The tests are slightly too verbose and
should be later refactor to use configuration for version
of SDK value instead of using hardcoded strings.

:art: Always create global.json at the project root

This commit actually update all main generator option scripts
to always output `global.json` file on the root of the project
in order to fix problems reported by users with applications
deployed to service like Azure web applications.
When the SDK and dotnet is more mature there should be no longer
required for such fix hopefully

The same feature could be implemented as an startup option, for
example as `--global` option, but it seemed to be more user friendly
to just output that automatically - as the entire dotnet project
concept is still under active rewrite during .csproj migration

Thanks!

/cc
@stewartadam
@OmniSharp/generator-aspnet-team-push
