### PR TITLE
Update Nancy template for 2.0.0-clinteastwood

### DIFF
--- a/templates/projects/nancy/project.json
+++ b/templates/projects/nancy/project.json
@@ -11,7 +11,7 @@
                 "Microsoft.AspNetCore.Hosting": "1.0.0",
                 "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
                 "Microsoft.AspNetCore.Owin": "1.0.0",
-                "Nancy": "2.0.0-barneyrubble",
+                "Nancy": "2.0.0-clinteastwood",
                 "Microsoft.NETCore.App": {
                     "type": "platform",
                     "version": "1.0.1"


### PR DESCRIPTION
This commit updates **Nancy** template to the new version **2.0.0-clinteastwood** in the **project.json** file while the **.csproj** is not yet available.

Refer to: [Nancy 2.0.0-clinteastwood](https://www.nuget.org/packages/Nancy/2.0.0-clinteastwood)

Summary of the changes in this PR:
 - Changing the **project.json** file:
from
`"Nancy": "2.0.0-barneyrubble",`
to
`"Nancy": "2.0.0-clinteastwood",`

Nothing else.

Thanks!

@OmniSharp/generator-aspnet-team-push