### PR TITLE
Version/option to specify content runtime support. Closes #863

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ The F# Templates are based on [Core F# Templates](https://github.com/odytrice/co
 
 The templates that use client-side libraries are calling the `bower install` script to install Bower managed dependencies. You can skip the installation process by passing the `--skip-install` option to the generator, e.g. `yo aspnet --skip-install`. This should allow for a better experience when `Development` has been enabled.
 
+The templates support both `LTS` and `Current` version of runtime. The `LTS` version is enabled by default (or enforced by `--version-lts` option). You can switch to `Current` version at any time by passing `--version-current` option when invoking generator: `yo aspnet --version-current`.
+
 ## Command line automation
 
 The project type and application name can be specified as optional command line arguments:

--- a/app/USAGE
+++ b/app/USAGE
@@ -2,6 +2,10 @@ Description:
 
   Creates a basic ASP.NET Core application
 
+Options:
+
+  --version-current the created content will use `Current` version of runtime dependencies
+
 Subgenerators:
 
   yo aspnet:angularcontroller [options] <name>

--- a/app/index.js
+++ b/app/index.js
@@ -6,6 +6,7 @@ var mkdirp = require('mkdirp');
 var path = require('path');
 var guid = require('uuid');
 var projectName = require('vs_projectname');
+var pckg = require('../package.json');
 var AspnetGenerator = yeoman.generators.Base.extend({
 
   constructor: function() {
@@ -145,6 +146,12 @@ var AspnetGenerator = yeoman.generators.Base.extend({
     this.templatedata.sqlite = (this.type === 'web') ? true : false;
     this.templatedata.ui = this.ui;
     this.templatedata.version = "1.0.0-preview2-1-003177";
+    this.templatedata.dotnet = {
+      version: this.options['versionCurrent'] ?
+        pckg.dotnet.current.version : pckg.dotnet.lts.version,
+      targetFramework: this.options['versionCurrent'] ?
+        pckg.dotnet.current.targetFramework : pckg.dotnet.lts.targetFramework
+    };
   },
 
   askForName: function() {

--- a/package.json
+++ b/package.json
@@ -66,5 +66,15 @@
   },
   "scripts": {
     "test": "mocha"
+  },
+  "dotnet": {
+    "lts": {
+      "version": "1.0.3",
+      "targetFramework": "netcoreapp1.0"
+    },
+    "current": {
+      "version": "1.1.0",
+      "targetFramework": "netcoreapp1.1"
+    }
   }
 }

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -13,6 +13,24 @@ describe('aspnet Core 1.0 generator', function() {
   });
 });
 
+/*
+* package.json contains dotnet target and version information
+*/
+describe('package.json contains dotnet version information', function() {
+  var pckg = require('../package.json');
+  it('contains expected LTS version', function() {
+    yeoman.assert.equal('1.0.3', pckg.dotnet.lts.version);
+  });
+  it('contains expected LTS target framework', function() {
+    yeoman.assert.equal('netcoreapp1.0', pckg.dotnet.lts.targetFramework);
+  });
+  it('contains expected Current version', function() {
+    yeoman.assert.equal('1.1.0', pckg.dotnet.current.version);
+  });
+  it('contains expected LTS version', function() {
+    yeoman.assert.equal('netcoreapp1.1', pckg.dotnet.current.targetFramework);
+  });
+});
 
 /*
  * yo aspnet Empty Application


### PR DESCRIPTION
Closes #863.

These commits allows to specify `--version-current` (`--version-lts`) to switch cotnent support at runtime depending on user choice.
The template variables will be set according to user option - with option `--version-lts` (1.0.3) used as default one.

There is no actual tests for usage of variable replacement in generators as no `.csproj` based projects are ready yet. I've tested it with manually mocked `emptyweb` project to be sure that variables are replaced.
When merged test should be added to individual project tests.

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push
