### PR TITLE
Add placeholder variable for ApplicationInsights

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -150,6 +150,7 @@ var AspnetGenerator = yeoman.generators.Base.extend({
   _buildTemplateData: function() {
     this.templatedata.namespace = projectName(this.applicationName);
     this.templatedata.applicationname = this.applicationName;
+    this.templatedata.includeApplicationInsights = false;
     this.templatedata.guid = guid.v4();
     this.templatedata.sqlite = (this.type === 'web') ? true : false;
     this.templatedata.ui = this.ui;


### PR DESCRIPTION
This adds placeholder for adding option for users to decide if
ApplicationInsight should be part of created content. That
option is available - but not used - in dotnet/cli templating
and as the content will be synchronized - it will be better
to have that placeholder for someone integrating templates between
repos.

https://github.com/dotnet/templating/blob/master/template_feed/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/Program.cs#L20-L22

The templates will contain an <%= if(....) => block

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push

