### PR TITLE
Update Nuget config file for RC. Closes #909

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The alphabetic list of available sub generators (_to create files after the proj
 * [aspnet:middleware](#middleware)
 * [aspnet:mvccontroller](#mvccontroller)
 * [aspnet:mvcview](#mvcview)
-* [aspnet:nuget](#nuget)
+* [aspnet:nugetconfig](#nugetconfig)
 * [aspnet:program](#program)
 * [aspnet:readme](#readme)
 * [aspnet:startup](#startup)
@@ -257,18 +257,17 @@ Produces `/ContactView.cshtml`
 
 [Return to top](#top)
 
-### nuget
+### nugetconfig
 
-Creates a new `NuGet.config` file. The support for unstable development
-feed is provided by `--unstable` option.
+Creates a new `NuGet.config` file.
 
 Example:
 
 ```
-yo aspnet:nuget --unstable
+yo aspnet:nugetconfig
 ```
 
-Produces `NuGet.config` with unstable NuGet feed
+Produces `NuGet.config`
 
 [Return to top](#top)
 

--- a/app/USAGE
+++ b/app/USAGE
@@ -16,7 +16,7 @@ Subgenerators:
   yo aspnet:middleware [options] <name>
   yo aspnet:mvccontroller [options] <name>
   yo aspnet:mvcview [options] <name>
-  yo aspnet:nuget [options]
+  yo aspnet:nugetconfig [options]
   yo aspnet:program [options]
   yo aspnet:startup [options]
   yo aspnet:taghelper [options] <name>

--- a/nugetconfig/USAGE
+++ b/nugetconfig/USAGE
@@ -2,7 +2,7 @@ Description:
     Creates a new NuGet configuration file
 
 Example:
-    yo aspnet:nuget
+    yo aspnet:nugetconfig
 
     This will create:
         nuget.config

--- a/nugetconfig/index.js
+++ b/nugetconfig/index.js
@@ -9,11 +9,5 @@ var Generator = module.exports = function Generator() {
 util.inherits(Generator, ScriptBase);
 
 Generator.prototype.createItem = function() {
-  // supports unstable feed via optional --unstable cli argument
-  this.generateTemplateFile(
-    '_nuget.config',
-    'NuGet.config', {
-      unstable: (this.options.unstable ? this.options.unstable : false)
-    }
-  );
+  this.generateStandardFile('nuget.config', 'nuget.config');
 };

--- a/templates/_nuget.config
+++ b/templates/_nuget.config
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear /> line below -->
-    <clear />
-    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" /><% if(unstable){ %>
-    <add key="dotnet.myget.org" value="https://dotnet.myget.org/F/aspnet1/api/v3/index.json" /><% } %>
-  </packageSources>
-</configuration>

--- a/templates/nuget.config
+++ b/templates/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+ <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+ </packageSources>
+</configuration>

--- a/test/subgenerators.js
+++ b/test/subgenerators.js
@@ -5,7 +5,7 @@ var path = require('path');
 /*
  * Test for all subgenerators NOT requiring a name argument
  */
-describe.skip('Subgenerators without arguments tests', function() {
+describe('Subgenerators without arguments tests', function() {
 
   describe('aspnet:program', function() {
     util.goCreate('program');
@@ -22,7 +22,7 @@ describe.skip('Subgenerators without arguments tests', function() {
     util.fileCheck('should create startup.cs file', 'Startup.cs');
   });
 
-  describe('aspnet:startup in cwd of project.json', function() {
+  describe.skip('aspnet:startup in cwd of project.json', function() {
     var dir = util.makeTempDir();
 
     util.goCreateApplication('classlib', 'emptyTest', dir);
@@ -74,29 +74,10 @@ describe.skip('Subgenerators without arguments tests', function() {
     util.fileContentCheck(filename, 'Calls database migrations', /RUN \["dotnet", "ef", "database", "update"\]/);
   });
 
-  describe('aspnet:nuget', function() {
-    util.goCreate('nuget');
-    var filename = 'NuGet.config';
+  describe('aspnet:nugetconfig', function() {
+    util.goCreate('nugetconfig');
+    var filename = 'nuget.config';
     util.fileCheck('should create NuGet configuration file', filename);
-    util.fileContentCheck(filename, 'Check file content', /api\.nuget\.org/);
-  });
-
-  // unstable feed cannot be found in generated file
-  describe('aspnet:nuget', function() {
-    util.goCreate('nuget');
-    var filename = 'NuGet.config';
-    util.fileCheck('should create NuGet configuration file', filename);
-    util.fileContentCheck(filename, 'Check file content', /api\.nuget\.org/);
-    util.noFileContentCheck(filename, 'Check file content for no unstable feed', /https:\/\/dotnet\.myget\.org\/F\/aspnet1\/api\/v3/);
-  });
-
-  // unstable feed should be found in generated file
-  describe('aspnet:nuget --unstable', function() {
-    var arg = '--unstable';
-    var filename = 'NuGet.config';
-    util.goCreateWithArgs('nuget', [arg]);
-    util.fileCheck('should create ' + filename + ' file with unstable feed', filename);
-    util.fileContentCheck(filename, 'Check file content for unstable feed', /https:\/\/dotnet\.myget\.org\/F\/aspnet1\/api\/v3/);
   });
 
   describe('aspnet:readme creates README.md', function() {
@@ -114,7 +95,7 @@ describe.skip('Subgenerators without arguments tests', function() {
     util.fileContentCheck(filename, 'Check file content', /^# MyNamespace$/m);
   });
 
-  describe('aspnet:readme in cwd of project.json should contain correct project name', function() {
+  describe.skip('aspnet:readme in cwd of project.json should contain correct project name', function() {
     var dir = util.makeTempDir();
     util.goCreateApplication('classlib', 'emptyTest', dir);
     util.goCreate('readme', path.join(dir, 'emptyTest'));
@@ -122,7 +103,7 @@ describe.skip('Subgenerators without arguments tests', function() {
     util.fileContentCheck('README.md', 'file content check', /^# emptyTest$/m);
   });
 
-  describe('aspnet:readme with --txt option in cwd of project.json should contain correct project name', function() {
+  describe.skip('aspnet:readme with --txt option in cwd of project.json should contain correct project name', function() {
     var arg = '--txt';
     var dir = util.makeTempDir();
     util.goCreateApplication('classlib', 'emptyTest', dir);


### PR DESCRIPTION
This commit:
- update content of nuget.config
- change name of the generator to `nugetconfig` to stay
aligned with `dotnet/cli` i `dotnet/templating`
- remove non-relevant optiont (--unstable feeds)
- docs update

Note that some tests are still skipped - but not for this
subgenerator

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push
