### PR TITLE
from C# templates removed beta versions of dependencies

### DIFF
--- a/templates/projects/mstest/Company.TestProject1.csproj
+++ b/templates/projects/mstest/Company.TestProject1.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161123-03" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.5-preview" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.0.6-preview" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.1.11" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
   </ItemGroup>
 
 </Project>

--- a/templates/projects/mvc/Company.WebApplication1.csproj
+++ b/templates/projects/mvc/Company.WebApplication1.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <% if(dotnet.targetFramework !== 'netcoreapp1.1'){ %>
   <ItemGroup><% if(includeApplicationInsights){ %>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0-beta1" /><% } %>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" /><% } %>
     <PackageReference Include="Microsoft.AspNetCore" Version="1.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.0.2" />
@@ -25,20 +25,20 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Design" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.0.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="1.0.0-msbuild3-final" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="1.1.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.0.2"  />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="1.0.0-msbuild3-final" />
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.0-msbuild3-final" />
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0-msbuild3-final" />
+    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="1.0.0" />
+    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.0" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0" />
   </ItemGroup>
   <% } %>
   <% if(dotnet.targetFramework === 'netcoreapp1.1'){ %>
   <ItemGroup><% if(includeApplicationInsights){ %>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0-beta1" /><% } %>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" /><% } %>
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.1.1" />
@@ -50,15 +50,15 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Design" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="1.0.0-msbuild3-final" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="1.1.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.1.1" />
     <<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="1.0.0-msbuild3-final" />
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.0-msbuild3-final" />
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0-msbuild3-final" />
+    <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="1.0.0" />
+    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.0" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0" />
   </ItemGroup>
   <% } %>
 </Project>

--- a/templates/projects/mvcbasic/Company.WebApplication1.csproj
+++ b/templates/projects/mvcbasic/Company.WebApplication1.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <% if(dotnet.targetFramework !== 'netcoreapp1.1'){ %>
   <ItemGroup><% if(includeApplicationInsights){ %>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0-beta1" /><% } %>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" /><% } %>
     <PackageReference Include="Microsoft.AspNetCore" Version="1.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.0.2" />
@@ -18,12 +18,12 @@
   <% } %>
   <% if(dotnet.targetFramework === 'netcoreapp1.1'){ %>
   <ItemGroup><% if(includeApplicationInsights){ %>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0-beta1" /><% } %>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" /><% } %>
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="1.1.0-msbuild3-update1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="1.1.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.1" />
-    <<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.0" />
   </ItemGroup>
   <% } %>

--- a/templates/projects/web/Company.WebApplication1.csproj
+++ b/templates/projects/web/Company.WebApplication1.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup><% if(includeApplicationInsights){ %>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0-beta1" /><% } %>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" /><% } %>
     <PackageReference Include="Microsoft.AspNetCore" Version="<%= dotnet.version %>" />
   </ItemGroup>
 

--- a/templates/projects/webapi/Company.WebApplication1.csproj
+++ b/templates/projects/webapi/Company.WebApplication1.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
   <% if(dotnet.targetFramework !== 'netcoreapp1.1'){ %>
   <ItemGroup><% if(includeApplicationInsights){ %>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0-beta1" /><% } %>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" /><% } %>
     <PackageReference Include="Microsoft.AspNetCore" Version="1.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.0.2" />
@@ -17,7 +17,7 @@
   <% } %>
   <% if(dotnet.targetFramework === 'netcoreapp1.1'){ %>
   <ItemGroup><% if(includeApplicationInsights){ %>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0-beta1" /><% } %>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" /><% } %>
     <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
     <<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />

--- a/templates/projects/xunit/Company.TestProject1.csproj
+++ b/templates/projects/xunit/Company.TestProject1.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161123-03" />
-    <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta4-build1194" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Summary of the changes in this PR:
from all C# templates removed beta versions of dependencies

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push
