### PR TITLE
Remove ASP.NET MVC 5/6 naming

### DIFF
--- a/templates/overrides/semantic/mvc/Views/Home/Index.cshtml
+++ b/templates/overrides/semantic/mvc/Views/Home/Index.cshtml
@@ -36,8 +36,8 @@
         <div class="ui segment">
             <h1 class="ui black ribbon label">Overview</h1>
             <ol class="ui list">
-                <li><a href="https://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET 5</a></li>
-                <li><a href="https://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET 5 such as Startup and middleware.</a></li>
+                <li><a href="https://go.microsoft.com/fwlink/?LinkId=518008">Conceptual overview of what is ASP.NET Core</a></li>
+                <li><a href="https://go.microsoft.com/fwlink/?LinkId=699320">Fundamentals of ASP.NET Core such as Startup and middleware.</a></li>
                 <li><a href="https://go.microsoft.com/fwlink/?LinkId=398602">Working with Data</a></li>
                 <li><a href="https://go.microsoft.com/fwlink/?LinkId=398603">Security</a></li>
                 <li><a href="https://go.microsoft.com/fwlink/?LinkID=699321">Client side development</a></li>
@@ -65,9 +65,9 @@
         <div class="ui segment">
             <h1 class="ui black ribbon label">Application Uses</h1>
             <ol class="left aligned ui list">
-                <li>Sample pages using ASP.NET MVC 6</li>
+                <li>Sample pages using ASP.NET Core</li>
                 <li><a href="https://go.microsoft.com/fwlink/?LinkId=518007">Gulp</a> and <a href="https://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
-                <li>Theming using <a href="https://go.microsoft.com/fwlink/?LinkID=398939">Bootstrap</a></li>
+                <li>Theming using <a href="https://semantic-ui.com/">Semantic UI</a></li>
             </ol>
         </div>
     </div>


### PR DESCRIPTION
removed reference to naming "ASP.NET MVC 5/6"
Update theming info to point to Semantic UI

Fixes #946 .

Summary of the changes in this PR:
 - Remove wording "ASP.NET MVC 5" or "ASP.NET MVC 6" and use "ASP.NET Core"
 - Update theme info to Semantic UI 

Thanks!

/cc
@OmniSharp/generator-aspnet-team-push
